### PR TITLE
Add `nsteps` and `extra_args` support to the API

### DIFF
--- a/api/gromacs/runner.py
+++ b/api/gromacs/runner.py
@@ -31,6 +31,7 @@ def run_mdrun(
     trial_id: str,
     job_id: str,
     extra_args: str = "",
+    nsteps: int = 25_000,
     best_steps_per_sec: float = 0.0,
 ) -> tuple[float, float, bool]:
     """
@@ -42,6 +43,7 @@ def run_mdrun(
         trial_id: Unique trial identifier
         job_id: Parent job identifier
         extra_args: Additional mdrun arguments
+        nsteps: Number of steps to run
         best_steps_per_sec: Best steps/sec observed so far (for early stopping)
 
     Returns:
@@ -54,7 +56,7 @@ def run_mdrun(
     env = os.environ.copy()
     env["OMP_NUM_THREADS"] = str(config.ntomp)
 
-    cmd = _build_command(config, tpr_path)
+    cmd = _build_command(config, tpr_path, nsteps)
     if extra_args:
         cmd += shlex.split(extra_args)
 
@@ -78,7 +80,7 @@ def run_mdrun(
     return performance, final_steps_per_sec, False
 
 
-def _build_command(config: TrialConfig, tpr_path: str) -> list[str]:
+def _build_command(config: TrialConfig, tpr_path: str, nsteps: int = 25_000) -> list[str]:
     """Build the mpirun + gmx mdrun command."""
     cmd = [
         "mpirun",
@@ -95,6 +97,8 @@ def _build_command(config: TrialConfig, tpr_path: str) -> list[str]:
         config.pme,
         "-s",
         tpr_path,
+        "-nsteps",
+        str(nsteps),
         "-cpt",
         "-1",  # Disable checkpointing for tuning
     ]

--- a/api/main.py
+++ b/api/main.py
@@ -12,7 +12,7 @@ import yaml
 from fastapi import Depends, FastAPI, File, HTTPException, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 from sqlalchemy.exc import OperationalError
 from starlette.concurrency import run_in_threadpool
 
@@ -27,7 +27,7 @@ from api.db.operations import (
 )
 from api.rayworker import cancel_job, submit_tuning_job, sync_job_status
 from api.schemas import JobStatus, JobStatusResponse, TrialResponse
-from api.utils import cleanup_tmp_files, get_cluster_status
+from api.utils import cleanup_tmp_files, get_cluster_status, sanitize_extra_args
 
 logger = logging.getLogger(__name__)
 
@@ -77,16 +77,23 @@ async def create_tuner_run(
     _: Annotated[HTTPBasicCredentials, Depends(verify_credentials)],
     file: Annotated[UploadFile, File()],
     nsteps: int = 25_000,
+    extra_args: str = "",
 ) -> APIResponse:
     """Start a new hyperparameter tuning run with a .tpr file."""
     _validate_upload(file, ".tpr")
     file_path = TPR_DIR / f"{uuid.uuid4()}_md.tpr"
     await run_in_threadpool(_save_upload, file, file_path)
 
+    # Sanitize extra_args
+    try:
+        sanitized_args = sanitize_extra_args(extra_args)
+    except ValidationError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
     job_id = str(uuid.uuid4())
     cleanup_tmp_files(job_id)
     try:
-        submit_tuning_job(job_id, str(file_path), job_type="standard", nsteps=nsteps)
+        submit_tuning_job(job_id, str(file_path), job_type="standard", extra_args=sanitized_args, nsteps=nsteps)
     except Exception as e:
         logger.exception("Failed to submit tuning job %s", job_id)
         raise HTTPException(status_code=500, detail=f"Failed to submit job: {e}") from e
@@ -158,6 +165,12 @@ async def run_custom_single_endpoint(
     """Run a custom GROMACS tuning job with extra arguments."""
     _validate_upload(file, ".zip")
 
+    # Sanitize extra_args
+    try:
+        sanitized_args = sanitize_extra_args(extra_args)
+    except ValidationError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
     with TemporaryDirectory() as tmpdir:
         tmpdir_path = Path(tmpdir)
         zip_path = tmpdir_path / "input.zip"
@@ -176,7 +189,7 @@ async def run_custom_single_endpoint(
     job_id = str(uuid.uuid4())
     cleanup_tmp_files(job_id)
     try:
-        submit_tuning_job(job_id, str(dest), job_type="custom", extra_args=extra_args)
+        submit_tuning_job(job_id, str(dest), job_type="custom", extra_args=sanitized_args)
     except Exception as e:
         logger.exception("Failed to submit custom job %s", job_id)
         raise HTTPException(status_code=500, detail=f"Failed to submit job: {e}") from e

--- a/api/main.py
+++ b/api/main.py
@@ -84,7 +84,6 @@ async def create_tuner_run(
     file_path = TPR_DIR / f"{uuid.uuid4()}_md.tpr"
     await run_in_threadpool(_save_upload, file, file_path)
 
-    # Sanitize extra_args
     try:
         sanitized_args = sanitize_extra_args(extra_args)
     except (ValidationError, ValueError) as e:
@@ -165,7 +164,6 @@ async def run_custom_single_endpoint(
     """Run a custom GROMACS tuning job with extra arguments."""
     _validate_upload(file, ".zip")
 
-    # Sanitize extra_args
     try:
         sanitized_args = sanitize_extra_args(extra_args)
     except (ValidationError, ValueError) as e:

--- a/api/main.py
+++ b/api/main.py
@@ -74,7 +74,9 @@ def _save_upload(file: UploadFile, dest: Path) -> None:
 
 @app.post("/api/tuner_runs")
 async def create_tuner_run(
-    _: Annotated[HTTPBasicCredentials, Depends(verify_credentials)], file: Annotated[UploadFile, File()]
+    _: Annotated[HTTPBasicCredentials, Depends(verify_credentials)],
+    file: Annotated[UploadFile, File()],
+    nsteps: int = 25_000,
 ) -> APIResponse:
     """Start a new hyperparameter tuning run with a .tpr file."""
     _validate_upload(file, ".tpr")
@@ -84,7 +86,7 @@ async def create_tuner_run(
     job_id = str(uuid.uuid4())
     cleanup_tmp_files(job_id)
     try:
-        submit_tuning_job(job_id, str(file_path), job_type="standard")
+        submit_tuning_job(job_id, str(file_path), job_type="standard", nsteps=nsteps)
     except Exception as e:
         logger.exception("Failed to submit tuning job %s", job_id)
         raise HTTPException(status_code=500, detail=f"Failed to submit job: {e}") from e

--- a/api/main.py
+++ b/api/main.py
@@ -9,7 +9,7 @@ from tempfile import TemporaryDirectory
 from typing import Annotated, Any
 
 import yaml
-from fastapi import Depends, FastAPI, File, HTTPException, UploadFile
+from fastapi import Depends, FastAPI, File, Form, HTTPException, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from pydantic import BaseModel, Field, ValidationError
@@ -76,8 +76,8 @@ def _save_upload(file: UploadFile, dest: Path) -> None:
 async def create_tuner_run(
     _: Annotated[HTTPBasicCredentials, Depends(verify_credentials)],
     file: Annotated[UploadFile, File()],
-    nsteps: int = 25_000,
-    extra_args: str = "",
+    nsteps: Annotated[int, Form(ge=1, description="Number of steps for GROMACS simulation")] = 25_000,
+    extra_args: Annotated[str, Form(description="Extra GROMACS arguments")] = "",
 ) -> APIResponse:
     """Start a new hyperparameter tuning run with a .tpr file."""
     _validate_upload(file, ".tpr")
@@ -87,7 +87,7 @@ async def create_tuner_run(
     # Sanitize extra_args
     try:
         sanitized_args = sanitize_extra_args(extra_args)
-    except ValidationError as e:
+    except (ValidationError, ValueError) as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
     job_id = str(uuid.uuid4())
@@ -160,7 +160,7 @@ async def get_status(job_id: str, _: Annotated[HTTPBasicCredentials, Depends(ver
 async def run_custom_single_endpoint(
     _: Annotated[HTTPBasicCredentials, Depends(verify_credentials)],
     file: Annotated[UploadFile, File()],
-    extra_args: str = "",
+    extra_args: Annotated[str, Form(description="Extra GROMACS arguments")] = "",
 ) -> APIResponse:
     """Run a custom GROMACS tuning job with extra arguments."""
     _validate_upload(file, ".zip")
@@ -168,7 +168,7 @@ async def run_custom_single_endpoint(
     # Sanitize extra_args
     try:
         sanitized_args = sanitize_extra_args(extra_args)
-    except ValidationError as e:
+    except (ValidationError, ValueError) as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
     with TemporaryDirectory() as tmpdir:

--- a/api/rayworker/tuner.py
+++ b/api/rayworker/tuner.py
@@ -55,20 +55,22 @@ def _run_single_trial(
     config: TrialConfig,
     cfg_hash: str,
     extra_args: str,
+    nsteps: int = 25_000,
     best_steps_per_sec: float = 0.0,
 ) -> dict[str, Any]:
     """Execute a single GROMACS trial on a Ray worker."""
     logger.info(
-        "Running trial %s: ntomp=%d, np=%d, nb=%s, pme=%s (best_sps=%.1f)",
+        "Running trial %s: ntomp=%d, np=%d, nb=%s, pme=%s, nsteps=%d (best_sps=%.1f)",
         trial_id,
         config.ntomp,
         config.np,
         config.nb,
         config.pme,
+        nsteps,
         best_steps_per_sec,
     )
     performance, steps_per_sec, early_stopped = run_mdrun(
-        config, tpr_path, trial_id, job_id, extra_args, best_steps_per_sec
+        config, tpr_path, trial_id, job_id, extra_args, nsteps, best_steps_per_sec
     )
     status = JobStatus.TERMINATED if performance > 0 or early_stopped else JobStatus.ERROR
     logger.info(
@@ -106,6 +108,7 @@ def _submit_trials(
     extra_args: str,
     tpr_hash: str,
     trials: list[TrialConfigEntry],
+    nsteps: int,
     best_steps_per_sec: float,
 ) -> dict[ray.ObjectRef, str]:
     """Submit a batch of trials to Ray and return futures map."""
@@ -118,6 +121,7 @@ def _submit_trials(
             cfg,
             cfg_hash,
             extra_args,
+            nsteps,  # type: ignore
             best_steps_per_sec,  # type: ignore
         )
         future_to_hash[future] = cfg_hash
@@ -163,7 +167,7 @@ def _process_trial_results(
     return new_best
 
 
-def _run_tuning_async(job_id: str, tpr_path: str, extra_args: str = "") -> None:
+def _run_tuning_async(job_id: str, tpr_path: str, extra_args: str = "", nsteps: int = 25_000) -> None:
     """Run grid search tuning in a background thread with early stopping support."""
     try:
         _ensure_ray_initialized()
@@ -193,13 +197,15 @@ def _run_tuning_async(job_id: str, tpr_path: str, extra_args: str = "") -> None:
         remaining_trials = trial_configs[baseline_count:]
 
         if baseline_trials:
-            future_to_hash = _submit_trials(job_id, tpr_path, extra_args, tpr_hash, baseline_trials, best_steps_per_sec)
+            future_to_hash = _submit_trials(
+                job_id, tpr_path, extra_args, tpr_hash, baseline_trials, nsteps, best_steps_per_sec
+            )
             best_steps_per_sec = _process_trial_results(job_id, tpr_hash, future_to_hash, best_steps_per_sec)
 
         batch_size = max(1, EARLY_STOP_BATCH_SIZE)
         for idx in range(0, len(remaining_trials), batch_size):
             batch = remaining_trials[idx : idx + batch_size]
-            future_to_hash = _submit_trials(job_id, tpr_path, extra_args, tpr_hash, batch, best_steps_per_sec)
+            future_to_hash = _submit_trials(job_id, tpr_path, extra_args, tpr_hash, batch, nsteps, best_steps_per_sec)
             best_steps_per_sec = _process_trial_results(job_id, tpr_hash, future_to_hash, best_steps_per_sec)
 
         logger.info("All trials completed for job %s (best: %.1f steps/s)", job_id, best_steps_per_sec)
@@ -212,10 +218,12 @@ def _run_tuning_async(job_id: str, tpr_path: str, extra_args: str = "") -> None:
             _active_jobs.pop(job_id, None)
 
 
-def submit_tuning_job(job_id: str, tpr_path: str, job_type: str = "standard", extra_args: str = "") -> str:
+def submit_tuning_job(
+    job_id: str, tpr_path: str, job_type: str = "standard", extra_args: str = "", nsteps: int = 25_000
+) -> str:
     """Submit a GROMACS tuning job."""
     create_job(job_id, job_type, tpr_path, extra_args or None)
-    thread = threading.Thread(target=_run_tuning_async, args=(job_id, tpr_path, extra_args), daemon=True)
+    thread = threading.Thread(target=_run_tuning_async, args=(job_id, tpr_path, extra_args, nsteps), daemon=True)
     with _job_lock:
         _active_jobs[job_id] = thread
     thread.start()

--- a/api/utils.py
+++ b/api/utils.py
@@ -3,6 +3,8 @@
 import hashlib
 import logging
 import os
+import re
+import shlex
 import shutil
 import time
 from collections import deque
@@ -10,10 +12,17 @@ from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from pathlib import Path
 
 import ray
+from pydantic import ValidationError
 
 from api.config import JOBS_DIR, TPR_DIR
 
 logger = logging.getLogger(__name__)
+
+# Forbidden shell metacharacters for extra_args validation
+_EXTRA_ARGS_FORBIDDEN_RE = re.compile(r"[;&|`$()<>]")
+
+# Forbidden GROMACS flags that should not be overridden
+_EXTRA_ARGS_FORBIDDEN_FLAGS = {"-deffnm", "-s", "-nsteps", "-ntomp", "-np", "-nb", "-pme"}
 
 
 def cleanup_tmp_files(job_id: str, directory: Path = TPR_DIR) -> None:
@@ -105,3 +114,44 @@ def tail(file: Path | str, n: int = 10) -> str:
             pos = chunk_start
 
         return b"\n".join(list(lines_found)[-n:]).decode("utf-8", "replace")
+
+
+def sanitize_extra_args(extra_args: str) -> str:
+    """
+    Validate and normalize extra GROMACS mdrun args.
+
+    This is used inside a shell script in the K8s job container, so we block
+    shell metacharacters and also forbid overriding critical args.
+
+    Args:
+        extra_args: Raw extra arguments string from user input.
+
+    Returns:
+        Canonicalized extra arguments string.
+
+    Raises:
+        ValidationError: If extra_args contains forbidden characters or patterns.
+    """
+    extra_args = (extra_args or "").strip()
+    if not extra_args:
+        return ""
+
+    # Block shell metacharacters
+    if _EXTRA_ARGS_FORBIDDEN_RE.search(extra_args):
+        raise ValidationError("extra_args contains forbidden characters: ; & | ` $ ( ) < >")
+
+    # Validate shell quoting
+    try:
+        tokens = shlex.split(extra_args, posix=True)
+    except ValueError as e:
+        raise ValidationError(f"Invalid extra_args: {e}") from e
+
+    # Check for forbidden flags (case-insensitive)
+    lowered = {t.lower() for t in tokens}
+    if lowered & _EXTRA_ARGS_FORBIDDEN_FLAGS:
+        raise ValidationError(
+            "extra_args must not override critical GROMACS flags: -deffnm, -s, -nsteps, -ntomp, -np, -nb, -pme"
+        )
+
+    # Canonicalize spacing/quoting
+    return shlex.join(tokens)

--- a/api/utils.py
+++ b/api/utils.py
@@ -12,7 +12,6 @@ from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from pathlib import Path
 
 import ray
-from pydantic import ValidationError
 
 from api.config import JOBS_DIR, TPR_DIR
 
@@ -130,7 +129,7 @@ def sanitize_extra_args(extra_args: str) -> str:
         Canonicalized extra arguments string.
 
     Raises:
-        ValidationError: If extra_args contains forbidden characters or patterns.
+        ValueError: If extra_args contains forbidden characters or patterns.
     """
     extra_args = (extra_args or "").strip()
     if not extra_args:
@@ -138,18 +137,18 @@ def sanitize_extra_args(extra_args: str) -> str:
 
     # Block shell metacharacters
     if _EXTRA_ARGS_FORBIDDEN_RE.search(extra_args):
-        raise ValidationError("extra_args contains forbidden characters: ; & | ` $ ( ) < >")
+        raise ValueError("extra_args contains forbidden characters: ; & | ` $ ( ) < >")
 
     # Validate shell quoting
     try:
         tokens = shlex.split(extra_args, posix=True)
     except ValueError as e:
-        raise ValidationError(f"Invalid extra_args: {e}") from e
+        raise ValueError(f"Invalid extra_args: {e}") from e
 
     # Check for forbidden flags (case-insensitive)
     lowered = {t.lower() for t in tokens}
     if lowered & _EXTRA_ARGS_FORBIDDEN_FLAGS:
-        raise ValidationError(
+        raise ValueError(
             "extra_args must not override critical GROMACS flags: -deffnm, -s, -nsteps, -ntomp, -np, -nb, -pme"
         )
 

--- a/api/utils.py
+++ b/api/utils.py
@@ -119,9 +119,6 @@ def sanitize_extra_args(extra_args: str) -> str:
     """
     Validate and normalize extra GROMACS mdrun args.
 
-    This is used inside a shell script in the K8s job container, so we block
-    shell metacharacters and also forbid overriding critical args.
-
     Args:
         extra_args: Raw extra arguments string from user input.
 
@@ -135,7 +132,6 @@ def sanitize_extra_args(extra_args: str) -> str:
     if not extra_args:
         return ""
 
-    # Block shell metacharacters
     if _EXTRA_ARGS_FORBIDDEN_RE.search(extra_args):
         raise ValueError("extra_args contains forbidden characters: ; & | ` $ ( ) < >")
 
@@ -145,7 +141,6 @@ def sanitize_extra_args(extra_args: str) -> str:
     except ValueError as e:
         raise ValueError(f"Invalid extra_args: {e}") from e
 
-    # Check for forbidden flags (case-insensitive)
     lowered = {t.lower() for t in tokens}
     if lowered & _EXTRA_ARGS_FORBIDDEN_FLAGS:
         raise ValueError(

--- a/openapi/gromacs-tuner-openapi.yaml
+++ b/openapi/gromacs-tuner-openapi.yaml
@@ -28,6 +28,14 @@ paths:
       description: Uploads a `.tpr` file and starts a tuning process.
       security:
         - basicAuth: []
+      parameters:
+        - name: nsteps
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 25000
+          description: Number of steps to run in GROMACS mdrun.
       requestBody:
         required: true
         content:

--- a/openapi/gromacs-tuner-openapi.yaml
+++ b/openapi/gromacs-tuner-openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: "GROMACS Tuner API"
-  version: "1.1"
+  version: "1.2"
   description: "API for submitting and monitoring GROMACS tuning runs."
 
 servers:
@@ -36,6 +36,17 @@ paths:
             type: integer
             default: 25000
           description: Number of steps to run in GROMACS mdrun.
+        - name: extra_args
+          in: query
+          required: false
+          schema:
+            type: string
+            default: ""
+            example: "-plumed plumed.dat"
+          description: |
+            Additional GROMACS mdrun arguments.
+            Shell metacharacters (; & | ` $ ( ) < >) are forbidden.
+            Critical flags (-deffnm, -s, -nsteps, -ntomp, -np, -nb, -pme) cannot be overridden.
       requestBody:
         required: true
         content:
@@ -112,7 +123,12 @@ paths:
                   description: A `.zip` file with a `md.tpr` file and optionally other files.
                 extra_args:
                   type: string
-                  example: "-deffnm md -plumed plumed.dat"
+                  default: ""
+                  example: "-plumed plumed.dat"
+                  description: |
+                    Additional GROMACS mdrun arguments.
+                    Shell metacharacters (; & | ` $ ( ) < >) are forbidden.
+                    Critical flags (-deffnm, -s, -nsteps, -ntomp, -np, -nb, -pme) cannot be overridden.
       responses:
         "200":
           description: Custom tuning job started.

--- a/openapi/gromacs-tuner-openapi.yaml
+++ b/openapi/gromacs-tuner-openapi.yaml
@@ -28,36 +28,32 @@ paths:
       description: Uploads a `.tpr` file and starts a tuning process.
       security:
         - basicAuth: []
-      parameters:
-        - name: nsteps
-          in: query
-          required: false
-          schema:
-            type: integer
-            default: 25000
-          description: Number of steps to run in GROMACS mdrun.
-        - name: extra_args
-          in: query
-          required: false
-          schema:
-            type: string
-            default: ""
-            example: "-plumed plumed.dat"
-          description: |
-            Additional GROMACS mdrun arguments.
-            Shell metacharacters (; & | ` $ ( ) < >) are forbidden.
-            Critical flags (-deffnm, -s, -nsteps, -ntomp, -np, -nb, -pme) cannot be overridden.
       requestBody:
         required: true
         content:
           multipart/form-data:
             schema:
               type: object
+              required:
+                - file
               properties:
                 file:
                   type: string
                   format: binary
                   description: The `.tpr` file to be tuned.
+                nsteps:
+                  type: integer
+                  default: 25000
+                  minimum: 1
+                  description: Number of steps to run in GROMACS mdrun (must be at least 1).
+                extra_args:
+                  type: string
+                  default: ""
+                  example: "-plumed plumed.dat"
+                  description: |
+                    Additional GROMACS mdrun arguments.
+                    Shell metacharacters (; & | ` $ ( ) < >) are forbidden.
+                    Critical flags (-deffnm, -s, -nsteps, -ntomp, -np, -nb, -pme) cannot be overridden.
       responses:
         "200":
           description: Tuning run successfully started.


### PR DESCRIPTION
There was already extra_args support, it was just not exposed. So I added sanitization and implemented it into the API. As for the nsteps, this will simplify API calls from MDDash significantly, because before the TPR had to be modified on the MDDash side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Set number of GROMACS steps per run (nsteps, default 25,000) for single and tuning jobs.
  * Provide extra_args to pass additional mdrun arguments; inputs are validated and invalid values yield HTTP 400.
  * nsteps and sanitized extra_args are applied consistently across trials and tuning workflows.

* **Documentation**
  * API bumped to v1.2: POST /tuner_runs adds nsteps and extra_args; POST /custom_run adds extra_args with usage and restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->