### PR TITLE
Remove `tpr_hash` and `config_hash`, eliminate `/custom_run` and listing endpoints

### DIFF
--- a/api/db/models.py
+++ b/api/db/models.py
@@ -1,12 +1,13 @@
 """Database connection and ORM models for the GROMACS tuner."""
 
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
-from sqlalchemy import JSON, String, create_engine, event
-from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, sessionmaker
+from sqlalchemy import JSON, ForeignKey, String, create_engine, event
+from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, relationship, sessionmaker
 
-from api.config import DB_PATH
+from api.config import DB_PATH, TPR_DIR
 from api.gromacs.config import TrialConfig
 
 
@@ -21,36 +22,27 @@ class Job(Base):
 
     __tablename__ = "jobs"
 
-    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
-    job_id: Mapped[str] = mapped_column(String, unique=True, nullable=False, index=True)
-    ray_job_id: Mapped[str | None] = mapped_column(String, nullable=True)
-    job_type: Mapped[str] = mapped_column(String, nullable=False)
-    tpr_path: Mapped[str] = mapped_column(String, nullable=False)
-    total_configs: Mapped[int] = mapped_column(default=0)
+    id: Mapped[str] = mapped_column(String, primary_key=True, nullable=False)
+    type: Mapped[str] = mapped_column(String, nullable=False)
     status: Mapped[str] = mapped_column(String, nullable=False, index=True)
-    error: Mapped[str | None] = mapped_column(String, nullable=True)
     extra_args: Mapped[str | None] = mapped_column(String, nullable=True)
+    total_configs: Mapped[int] = mapped_column(default=0)
+    error: Mapped[str | None] = mapped_column(String, nullable=True)
     created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(timezone.utc))
     updated_at: Mapped[datetime] = mapped_column(
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
     )
 
-    def to_dict(self) -> dict[str, Any]:
-        """Convert the job object to a dictionary."""
-        return {
-            "id": self.id,
-            "job_id": self.job_id,
-            "ray_job_id": self.ray_job_id,
-            "job_type": self.job_type,
-            "tpr_path": self.tpr_path,
-            "total_configs": self.total_configs,
-            "status": self.status,
-            "error": self.error,
-            "extra_args": self.extra_args,
-            "created_at": self.created_at,
-            "updated_at": self.updated_at,
-        }
+    # Relationship with trials - cascade delete
+    trials: Mapped[list["Trial"]] = relationship(
+        "Trial", back_populates="job", cascade="all, delete-orphan", passive_deletes=True
+    )
+
+    @property
+    def tpr_path(self) -> Path:
+        """Get the TPR file path for this job."""
+        return TPR_DIR / f"{self.id}_md.tpr"
 
 
 class Trial(Base):
@@ -59,12 +51,14 @@ class Trial(Base):
     __tablename__ = "trials"
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
-    job_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
-    trial_id: Mapped[str] = mapped_column(String, nullable=False)
+    job_id: Mapped[str] = mapped_column(String, ForeignKey("jobs.id", ondelete="CASCADE"), nullable=False, index=True)
     config_json: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
     status: Mapped[str] = mapped_column(String, nullable=False)
     performance: Mapped[float | None] = mapped_column(nullable=True)
     created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(timezone.utc))
+
+    # Relationship with job
+    job: Mapped["Job"] = relationship("Job", back_populates="trials")
 
     @property
     def config(self) -> TrialConfig:

--- a/api/db/models.py
+++ b/api/db/models.py
@@ -4,11 +4,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from sqlalchemy import JSON, ForeignKey, String, create_engine, event
+from sqlalchemy import JSON, Enum, ForeignKey, String, create_engine, event
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, relationship, sessionmaker
 
 from api.config import DB_PATH, TPR_DIR
 from api.gromacs.config import TrialConfig
+from api.schemas import JobStatus
 
 
 class Base(DeclarativeBase):
@@ -23,9 +24,7 @@ class Job(Base):
     __tablename__ = "jobs"
 
     id: Mapped[str] = mapped_column(String, primary_key=True, nullable=False)
-    type: Mapped[str] = mapped_column(String, nullable=False)
-    status: Mapped[str] = mapped_column(String, nullable=False, index=True)
-    extra_args: Mapped[str | None] = mapped_column(String, nullable=True)
+    status: Mapped[JobStatus] = mapped_column(Enum(JobStatus, native_enum=False), nullable=False, index=True)
     total_configs: Mapped[int] = mapped_column(default=0)
     error: Mapped[str | None] = mapped_column(String, nullable=True)
     created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(timezone.utc))
@@ -53,7 +52,7 @@ class Trial(Base):
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     job_id: Mapped[str] = mapped_column(String, ForeignKey("jobs.id", ondelete="CASCADE"), nullable=False, index=True)
     config_json: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
-    status: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[JobStatus] = mapped_column(Enum(JobStatus, native_enum=False), nullable=False)
     performance: Mapped[float | None] = mapped_column(nullable=True)
     created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(timezone.utc))
 

--- a/api/db/models.py
+++ b/api/db/models.py
@@ -61,7 +61,6 @@ class Trial(Base):
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     job_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
     trial_id: Mapped[str] = mapped_column(String, nullable=False)
-    config_hash: Mapped[str] = mapped_column(String, nullable=False)
     config_json: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
     status: Mapped[str] = mapped_column(String, nullable=False)
     performance: Mapped[float | None] = mapped_column(nullable=True)

--- a/api/db/models.py
+++ b/api/db/models.py
@@ -25,7 +25,6 @@ class Job(Base):
 
     id: Mapped[str] = mapped_column(String, primary_key=True, nullable=False)
     status: Mapped[JobStatus] = mapped_column(Enum(JobStatus, native_enum=False), nullable=False, index=True)
-    total_configs: Mapped[int] = mapped_column(default=0)
     error: Mapped[str | None] = mapped_column(String, nullable=True)
     created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(timezone.utc))
     updated_at: Mapped[datetime] = mapped_column(

--- a/api/db/models.py
+++ b/api/db/models.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import JSON, Index, String, create_engine, event
+from sqlalchemy import JSON, String, create_engine, event
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, sessionmaker
 
 from api.config import DB_PATH
@@ -25,7 +25,6 @@ class Job(Base):
     job_id: Mapped[str] = mapped_column(String, unique=True, nullable=False, index=True)
     ray_job_id: Mapped[str | None] = mapped_column(String, nullable=True)
     job_type: Mapped[str] = mapped_column(String, nullable=False)
-    tpr_hash: Mapped[str | None] = mapped_column(String, nullable=True)
     tpr_path: Mapped[str] = mapped_column(String, nullable=False)
     total_configs: Mapped[int] = mapped_column(default=0)
     status: Mapped[str] = mapped_column(String, nullable=False, index=True)
@@ -44,7 +43,6 @@ class Job(Base):
             "job_id": self.job_id,
             "ray_job_id": self.ray_job_id,
             "job_type": self.job_type,
-            "tpr_hash": self.tpr_hash,
             "tpr_path": self.tpr_path,
             "total_configs": self.total_configs,
             "status": self.status,
@@ -63,17 +61,11 @@ class Trial(Base):
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     job_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
     trial_id: Mapped[str] = mapped_column(String, nullable=False)
-    tpr_hash: Mapped[str] = mapped_column(String, nullable=False, index=True)
     config_hash: Mapped[str] = mapped_column(String, nullable=False)
     config_json: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
     status: Mapped[str] = mapped_column(String, nullable=False)
     performance: Mapped[float | None] = mapped_column(nullable=True)
     created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(timezone.utc))
-
-    __table_args__ = (
-        Index("ix_tpr_config", "tpr_hash", "config_hash"),
-        Index("uq_tpr_config", "tpr_hash", "config_hash", unique=True),
-    )
 
     @property
     def config(self) -> TrialConfig:

--- a/api/db/operations.py
+++ b/api/db/operations.py
@@ -12,35 +12,33 @@ from api.schemas import JobStatus, TrialInfo
 logger = logging.getLogger(__name__)
 
 
-def create_job(job_id: str, job_type: str, tpr_path: str, extra_args: str | None = None) -> None:
+def create_job(id: str, type: str, extra_args: str | None = None) -> None:
     """Create a new job record with PENDING status."""
     with get_session() as session:
-        session.add(
-            Job(job_id=job_id, job_type=job_type, tpr_path=tpr_path, status=JobStatus.PENDING, extra_args=extra_args)
-        )
+        session.add(Job(id=id, type=type, status=JobStatus.PENDING, extra_args=extra_args))
         session.commit()
 
 
-def update_job_status(job_id: str, status: str, error: str | None = None) -> bool:
+def update_job_status(id: str, status: str, error: str | None = None) -> bool:
     """Update job status and optionally error message."""
     with get_session() as session:
-        if job := session.execute(select(Job).where(Job.job_id == job_id)).scalar_one_or_none():
+        if job := session.execute(select(Job).where(Job.id == id)).scalar_one_or_none():
             job.status, job.error, job.updated_at = status, error, datetime.now(timezone.utc)
             session.commit()
             return True
         return False
 
 
-def get_job(job_id: str) -> Job | None:
+def get_job(id: str) -> Job | None:
     """Get job record by ID."""
     with get_session() as session:
-        return session.execute(select(Job).where(Job.job_id == job_id)).scalar_one_or_none()
+        return session.execute(select(Job).where(Job.id == id)).scalar_one_or_none()
 
 
-def delete_job(job_id: str) -> bool:
+def delete_job(id: str) -> bool:
     """Delete a job record."""
     with get_session() as session:
-        if job := session.execute(select(Job).where(Job.job_id == job_id)).scalar_one_or_none():
+        if job := session.execute(select(Job).where(Job.id == id)).scalar_one_or_none():
             session.delete(job)
             session.commit()
             return True
@@ -49,52 +47,36 @@ def delete_job(job_id: str) -> bool:
 
 def create_trial_result(
     job_id: str,
-    trial_id: str,
     config: TrialConfig,
     status: JobStatus,
     performance: float | None,
-) -> bool:
-    """Create a trial result."""
+) -> int:
+    """Create a trial result. Returns the database trial ID."""
     with get_session() as session:
-        session.add(
-            Trial(
-                job_id=job_id,
-                trial_id=trial_id,
-                config_json=config.to_dict(),
-                status=status,
-                performance=performance,
-            )
+        trial = Trial(
+            job_id=job_id,
+            config_json=config.to_dict(),
+            status=status,
+            performance=performance,
         )
+        session.add(trial)
         session.commit()
-        return True
+        session.refresh(trial)
+        return trial.id
 
 
-def update_trial_result(trial_id: str, status: str, performance: float | None) -> bool:
+def update_trial_result(trial_id: int, status: str, performance: float | None) -> bool:
     """Update a trial's status and performance."""
     with get_session() as session:
-        if trial := session.execute(select(Trial).where(Trial.trial_id == trial_id)).scalar_one_or_none():
+        if trial := session.execute(select(Trial).where(Trial.id == trial_id)).scalar_one_or_none():
             trial.status, trial.performance = status, performance
             session.commit()
             return True
         return False
 
 
-def get_trials_by_job_id(job_id: str) -> dict[str, TrialInfo]:
-    """Get all trials for a specific job, mapped by trial_id."""
+def get_trials_by_job_id(job_id: str) -> dict[int, TrialInfo]:
+    """Get all trials for a specific job, mapped by trial ID."""
     with get_session() as session:
         trials = session.execute(select(Trial).where(Trial.job_id == job_id)).scalars().all()
-        return {t.trial_id: TrialInfo(config=t.config, status=t.status, performance=t.performance) for t in trials}
-
-
-def delete_incomplete_trials_by_job_id(job_id: str) -> int:
-    """Delete non-terminated trials for a job. Returns count of deleted rows."""
-    with get_session() as session:
-        trials = (
-            session.execute(select(Trial).where(Trial.job_id == job_id, Trial.status != JobStatus.TERMINATED))
-            .scalars()
-            .all()
-        )
-        for trial in trials:
-            session.delete(trial)
-        session.commit()
-        return len(trials)
+        return {t.id: TrialInfo(config=t.config, status=t.status, performance=t.performance) for t in trials}

--- a/api/db/operations.py
+++ b/api/db/operations.py
@@ -12,10 +12,10 @@ from api.schemas import JobStatus, TrialInfo
 logger = logging.getLogger(__name__)
 
 
-def create_job(id: str, type: str, extra_args: str | None = None) -> None:
+def create_job(id: str) -> None:
     """Create a new job record with PENDING status."""
     with get_session() as session:
-        session.add(Job(id=id, type=type, status=JobStatus.PENDING, extra_args=extra_args))
+        session.add(Job(id=id, status=JobStatus.PENDING))
         session.commit()
 
 

--- a/api/db/operations.py
+++ b/api/db/operations.py
@@ -19,7 +19,7 @@ def create_job(id: str, type: str, extra_args: str | None = None) -> None:
         session.commit()
 
 
-def update_job_status(id: str, status: str, error: str | None = None) -> bool:
+def update_job_status(id: str, status: JobStatus, error: str | None = None) -> bool:
     """Update job status and optionally error message."""
     with get_session() as session:
         if job := session.execute(select(Job).where(Job.id == id)).scalar_one_or_none():
@@ -65,7 +65,7 @@ def create_trial_result(
         return trial.id
 
 
-def update_trial_result(trial_id: int, status: str, performance: float | None) -> bool:
+def update_trial_result(trial_id: int, status: JobStatus, performance: float | None) -> bool:
     """Update a trial's status and performance."""
     with get_session() as session:
         if trial := session.execute(select(Trial).where(Trial.id == trial_id)).scalar_one_or_none():

--- a/api/db/operations.py
+++ b/api/db/operations.py
@@ -5,7 +5,6 @@ from collections.abc import Sequence
 from datetime import datetime, timezone
 
 from sqlalchemy import select
-from sqlalchemy.exc import IntegrityError
 
 from api.db.models import Job, Trial, get_session
 from api.gromacs.config import TrialConfig
@@ -33,11 +32,11 @@ def update_job_status(job_id: str, status: str, error: str | None = None) -> boo
         return False
 
 
-def update_job_config(job_id: str, tpr_hash: str, total_configs: int) -> bool:
-    """Update job with TPR hash and total config count."""
+def update_job_config(job_id: str, total_configs: int) -> bool:
+    """Update job with total config count."""
     with get_session() as session:
         if job := session.execute(select(Job).where(Job.job_id == job_id)).scalar_one_or_none():
-            job.tpr_hash, job.total_configs, job.updated_at = tpr_hash, total_configs, datetime.now(timezone.utc)
+            job.total_configs, job.updated_at = total_configs, datetime.now(timezone.utc)
             session.commit()
             return True
         return False
@@ -70,38 +69,31 @@ def delete_job(job_id: str) -> bool:
 def create_trial_result(
     job_id: str,
     trial_id: str,
-    tpr_hash: str,
     config: TrialConfig,
     config_hash: str,
     status: JobStatus,
     performance: float | None,
 ) -> bool:
-    """Create a trial result. Returns False if already exists."""
-    try:
-        with get_session() as session:
-            session.add(
-                Trial(
-                    job_id=job_id,
-                    trial_id=trial_id,
-                    tpr_hash=tpr_hash,
-                    config_hash=config_hash,
-                    config_json=config.to_dict(),
-                    status=status,
-                    performance=performance,
-                )
+    """Create a trial result."""
+    with get_session() as session:
+        session.add(
+            Trial(
+                job_id=job_id,
+                trial_id=trial_id,
+                config_hash=config_hash,
+                config_json=config.to_dict(),
+                status=status,
+                performance=performance,
             )
-            session.commit()
-            return True
-    except IntegrityError:
-        return False
+        )
+        session.commit()
+        return True
 
 
-def update_trial_result(tpr_hash: str, config_hash: str, status: str, performance: float | None) -> bool:
+def update_trial_result(config_hash: str, status: str, performance: float | None) -> bool:
     """Update a trial's status and performance."""
     with get_session() as session:
-        if trial := session.execute(
-            select(Trial).where(Trial.tpr_hash == tpr_hash, Trial.config_hash == config_hash)
-        ).scalar_one_or_none():
+        if trial := session.execute(select(Trial).where(Trial.config_hash == config_hash)).scalar_one_or_none():
             trial.status, trial.performance = status, performance
             session.commit()
             return True
@@ -113,28 +105,10 @@ def _trials_to_info_dict(trials: Sequence[Trial]) -> dict[str, TrialInfo]:
     return {t.trial_id: TrialInfo(config=t.config, status=t.status, performance=t.performance) for t in trials}
 
 
-def get_trials_by_tpr_hash(tpr_hash: str) -> dict[str, TrialInfo]:
-    """Get all trials for a given TPR hash, mapped by trial_id."""
-    with get_session() as session:
-        return _trials_to_info_dict(session.execute(select(Trial).where(Trial.tpr_hash == tpr_hash)).scalars().all())
-
-
 def get_trials_by_job_id(job_id: str) -> dict[str, TrialInfo]:
     """Get all trials for a specific job, mapped by trial_id."""
     with get_session() as session:
         return _trials_to_info_dict(session.execute(select(Trial).where(Trial.job_id == job_id)).scalars().all())
-
-
-def get_completed_config_hashes(tpr_hash: str) -> set[str]:
-    """Get set of config hashes that have been completed for a TPR."""
-    with get_session() as session:
-        return set(
-            session.execute(
-                select(Trial.config_hash).where(Trial.tpr_hash == tpr_hash, Trial.status == JobStatus.TERMINATED)
-            )
-            .scalars()
-            .all()
-        )
 
 
 def delete_incomplete_trials_by_job_id(job_id: str) -> int:

--- a/api/db/operations.py
+++ b/api/db/operations.py
@@ -1,7 +1,6 @@
 """Database operations for the GROMACS tuner."""
 
 import logging
-from collections.abc import Sequence
 from datetime import datetime, timezone
 
 from sqlalchemy import select
@@ -27,16 +26,6 @@ def update_job_status(job_id: str, status: str, error: str | None = None) -> boo
     with get_session() as session:
         if job := session.execute(select(Job).where(Job.job_id == job_id)).scalar_one_or_none():
             job.status, job.error, job.updated_at = status, error, datetime.now(timezone.utc)
-            session.commit()
-            return True
-        return False
-
-
-def update_job_config(job_id: str, total_configs: int) -> bool:
-    """Update job with total config count."""
-    with get_session() as session:
-        if job := session.execute(select(Job).where(Job.job_id == job_id)).scalar_one_or_none():
-            job.total_configs, job.updated_at = total_configs, datetime.now(timezone.utc)
             session.commit()
             return True
         return False
@@ -90,25 +79,21 @@ def create_trial_result(
         return True
 
 
-def update_trial_result(config_hash: str, status: str, performance: float | None) -> bool:
+def update_trial_result(trial_id: str, status: str, performance: float | None) -> bool:
     """Update a trial's status and performance."""
     with get_session() as session:
-        if trial := session.execute(select(Trial).where(Trial.config_hash == config_hash)).scalar_one_or_none():
+        if trial := session.execute(select(Trial).where(Trial.trial_id == trial_id)).scalar_one_or_none():
             trial.status, trial.performance = status, performance
             session.commit()
             return True
         return False
 
 
-def _trials_to_info_dict(trials: Sequence[Trial]) -> dict[str, TrialInfo]:
-    """Convert trial list to dict keyed by trial_id."""
-    return {t.trial_id: TrialInfo(config=t.config, status=t.status, performance=t.performance) for t in trials}
-
-
 def get_trials_by_job_id(job_id: str) -> dict[str, TrialInfo]:
     """Get all trials for a specific job, mapped by trial_id."""
     with get_session() as session:
-        return _trials_to_info_dict(session.execute(select(Trial).where(Trial.job_id == job_id)).scalars().all())
+        trials = session.execute(select(Trial).where(Trial.job_id == job_id)).scalars().all()
+        return {t.trial_id: TrialInfo(config=t.config, status=t.status, performance=t.performance) for t in trials}
 
 
 def delete_incomplete_trials_by_job_id(job_id: str) -> int:

--- a/api/db/operations.py
+++ b/api/db/operations.py
@@ -59,7 +59,6 @@ def create_trial_result(
     job_id: str,
     trial_id: str,
     config: TrialConfig,
-    config_hash: str,
     status: JobStatus,
     performance: float | None,
 ) -> bool:
@@ -69,7 +68,6 @@ def create_trial_result(
             Trial(
                 job_id=job_id,
                 trial_id=trial_id,
-                config_hash=config_hash,
                 config_json=config.to_dict(),
                 status=status,
                 performance=performance,

--- a/api/db/operations.py
+++ b/api/db/operations.py
@@ -37,14 +37,6 @@ def get_job(job_id: str) -> Job | None:
         return session.execute(select(Job).where(Job.job_id == job_id)).scalar_one_or_none()
 
 
-def get_jobs_by_status(statuses: list[str]) -> list[Job]:
-    """Get all jobs with the given statuses."""
-    if not statuses:
-        return []
-    with get_session() as session:
-        return list(session.execute(select(Job).where(Job.status.in_(statuses))).scalars().all())
-
-
 def delete_job(job_id: str) -> bool:
     """Delete a job record."""
     with get_session() as session:

--- a/api/gromacs/config.py
+++ b/api/gromacs/config.py
@@ -1,7 +1,5 @@
 """GROMACS configuration generation and validation."""
 
-import hashlib
-import json
 from dataclasses import dataclass
 from itertools import product
 from typing import Any
@@ -39,12 +37,6 @@ class TrialConfig:
     def num_gpus(self) -> int:
         """Total number of GPUs required for this config."""
         return int(self.nb == "gpu" or self.pme == "gpu")
-
-    @property
-    def hash(self) -> str:
-        """Generate a deterministic hash for a config (excluding runtime fields)."""
-        normalized = {"ntomp": self.ntomp, "np": self.np, "nb": self.nb, "pme": self.pme}
-        return hashlib.sha256(json.dumps(normalized, sort_keys=True).encode()).hexdigest()[:16]
 
     @classmethod
     def generate_all_configs(cls) -> list["TrialConfig"]:

--- a/api/gromacs/runner.py
+++ b/api/gromacs/runner.py
@@ -18,6 +18,7 @@ from api.config import (
     EARLY_STOP_WARMUP_SECONDS,
     EARLY_STOP_WARMUP_STEPS,
     JOBS_DIR,
+    TPR_DIR,
 )
 from api.gromacs.config import TrialConfig
 from api.utils import tail
@@ -27,7 +28,6 @@ logger = logging.getLogger(__name__)
 
 def run_mdrun(
     config: TrialConfig,
-    tpr_path: str,
     trial_id: str,
     job_id: str,
     extra_args: str = "",
@@ -39,7 +39,6 @@ def run_mdrun(
 
     Args:
         config: Trial configuration
-        tpr_path: Path to TPR file
         trial_id: Unique trial identifier
         job_id: Parent job identifier
         extra_args: Additional mdrun arguments
@@ -50,6 +49,7 @@ def run_mdrun(
         Tuple of (performance_ns_day, steps_per_sec, early_stopped).
         Returns (0.0, 0.0, False) on failure.
     """
+    tpr_path = str(TPR_DIR / f"{job_id}_md.tpr")
     trial_dir = JOBS_DIR / job_id / trial_id
     trial_dir.mkdir(parents=True, exist_ok=True)
 

--- a/api/main.py
+++ b/api/main.py
@@ -75,20 +75,21 @@ async def create_tuner_run(
     extra_args: Annotated[str, Form(description="Extra GROMACS arguments")] = "",
 ) -> APIResponse:
     """Start a new hyperparameter tuning run with a .tpr file."""
+    try:
+        sanitized_args = sanitize_extra_args(extra_args)
+    except (ValidationError, ValueError) as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
     _validate_upload(file, ".tpr")
     job_id = str(uuid.uuid4())
     file_path = TPR_DIR / f"{job_id}_md.tpr"
     await run_in_threadpool(_save_upload, file, file_path)
 
     try:
-        sanitized_args = sanitize_extra_args(extra_args)
-    except (ValidationError, ValueError) as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
-
-    try:
-        submit_tuning_job(job_id, type="standard", extra_args=sanitized_args, nsteps=nsteps)
+        submit_tuning_job(job_id, extra_args=sanitized_args, nsteps=nsteps)
     except Exception as e:
         logger.exception("Failed to submit tuning job %s", job_id)
+        await run_in_threadpool(cleanup_job_files, job_id)
         raise HTTPException(status_code=500, detail=f"Failed to submit job: {e}") from e
 
     logger.info("Started tuning job %s", job_id)

--- a/api/main.py
+++ b/api/main.py
@@ -16,7 +16,6 @@ from starlette.concurrency import run_in_threadpool
 
 from api.config import MAX_UPLOAD_SIZE, TPR_DIR, TUNER_PASSWORD, TUNER_USER
 from api.db.operations import (
-    delete_incomplete_trials_by_job_id,
     delete_job,
     get_job,
     get_trials_by_job_id,
@@ -77,7 +76,8 @@ async def create_tuner_run(
 ) -> APIResponse:
     """Start a new hyperparameter tuning run with a .tpr file."""
     _validate_upload(file, ".tpr")
-    file_path = TPR_DIR / f"{uuid.uuid4()}_md.tpr"
+    job_id = str(uuid.uuid4())
+    file_path = TPR_DIR / f"{job_id}_md.tpr"
     await run_in_threadpool(_save_upload, file, file_path)
 
     try:
@@ -85,18 +85,15 @@ async def create_tuner_run(
     except (ValidationError, ValueError) as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
-    job_id = str(uuid.uuid4())
     cleanup_tmp_files(job_id)
     try:
-        submit_tuning_job(job_id, str(file_path), job_type="standard", extra_args=sanitized_args, nsteps=nsteps)
+        submit_tuning_job(job_id, type="standard", extra_args=sanitized_args, nsteps=nsteps)
     except Exception as e:
         logger.exception("Failed to submit tuning job %s", job_id)
         raise HTTPException(status_code=500, detail=f"Failed to submit job: {e}") from e
 
     logger.info("Started tuning job %s", job_id)
-    return APIResponse(
-        success=True, data={"tuner_run_id": job_id, "status": JobStatus.PENDING}, message="Tuning job started"
-    )
+    return APIResponse(success=True, data={"id": job_id, "status": JobStatus.PENDING}, message="Tuning job started")
 
 
 @app.get("/api/tuner_runs/{job_id}/status")
@@ -121,6 +118,7 @@ async def get_status(job_id: str, _: Annotated[HTTPBasicCredentials, Depends(ver
     trials = [
         TrialResponse(
             id=tid,
+            trial_id=str(tid),
             status=t.status,
             ntomp=t.config.ntomp,
             np=t.config.np,
@@ -136,8 +134,8 @@ async def get_status(job_id: str, _: Annotated[HTTPBasicCredentials, Depends(ver
     return APIResponse(
         success=True,
         data=JobStatusResponse(
-            tuner_run_id=job_id,
-            job_status=job.status,
+            id=job_id,
+            status=job.status,
             summary=summary,
             trials=trials,
             cluster_resources=cluster_resources,
@@ -154,14 +152,13 @@ async def delete_tuner_run(job_id: str, _: Annotated[HTTPBasicCredentials, Depen
         raise HTTPException(status_code=404, detail=f"Job '{job_id}' not found")
 
     cancelled = await run_in_threadpool(cancel_job, job_id)
-    deleted_db_rows = await run_in_threadpool(delete_incomplete_trials_by_job_id, job_id)
     await run_in_threadpool(delete_job, job_id)
     cleanup_tmp_files(job_id)
 
-    logger.info("Deleted job %s: cancelled=%s, db_rows=%d", job_id, cancelled, deleted_db_rows)
+    logger.info("Deleted job %s: cancelled=%s", job_id, cancelled)
     return APIResponse(
         success=True,
-        data={"tuner_run_id": job_id, "deleted_db_rows": deleted_db_rows, "cancelled": cancelled},
+        data={"id": job_id, "cancelled": cancelled},
         message="Tuning job deleted",
     )
 

--- a/api/main.py
+++ b/api/main.py
@@ -2,10 +2,8 @@ import logging
 import secrets
 import shutil
 import uuid
-import zipfile
 from collections import Counter
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import Annotated, Any
 
 import yaml
@@ -21,7 +19,6 @@ from api.db.operations import (
     delete_incomplete_trials_by_job_id,
     delete_job,
     get_job,
-    get_jobs_by_status,
     get_trials_by_job_id,
 )
 from api.rayworker import cancel_job, submit_tuning_job, sync_job_status
@@ -150,49 +147,6 @@ async def get_status(job_id: str, _: Annotated[HTTPBasicCredentials, Depends(ver
     )
 
 
-@app.post("/api/custom_run")
-async def run_custom_single_endpoint(
-    _: Annotated[HTTPBasicCredentials, Depends(verify_credentials)],
-    file: Annotated[UploadFile, File()],
-    extra_args: Annotated[str, Form(description="Extra GROMACS arguments")] = "",
-) -> APIResponse:
-    """Run a custom GROMACS tuning job with extra arguments."""
-    _validate_upload(file, ".zip")
-
-    try:
-        sanitized_args = sanitize_extra_args(extra_args)
-    except (ValidationError, ValueError) as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
-
-    with TemporaryDirectory() as tmpdir:
-        tmpdir_path = Path(tmpdir)
-        zip_path = tmpdir_path / "input.zip"
-        await run_in_threadpool(_save_upload, file, zip_path)
-        with zipfile.ZipFile(zip_path, "r") as z:
-            z.extractall(tmpdir_path)
-
-        tpr_files = list(tmpdir_path.glob("*.tpr"))
-        if not tpr_files:
-            raise HTTPException(status_code=400, detail="Zip must contain at least one .tpr file")
-
-        dest = TPR_DIR / f"{uuid.uuid4()}_custom.tpr"
-        TPR_DIR.mkdir(parents=True, exist_ok=True)
-        shutil.copy(tpr_files[0], dest)
-
-    job_id = str(uuid.uuid4())
-    cleanup_tmp_files(job_id)
-    try:
-        submit_tuning_job(job_id, str(dest), job_type="custom", extra_args=sanitized_args)
-    except Exception as e:
-        logger.exception("Failed to submit custom job %s", job_id)
-        raise HTTPException(status_code=500, detail=f"Failed to submit job: {e}") from e
-
-    logger.info("Started custom job %s", job_id)
-    return APIResponse(
-        success=True, data={"tuner_run_id": job_id, "status": JobStatus.PENDING}, message="Custom job started"
-    )
-
-
 @app.delete("/api/tuner_runs/{job_id}")
 async def delete_tuner_run(job_id: str, _: Annotated[HTTPBasicCredentials, Depends(verify_credentials)]) -> APIResponse:
     """Delete a tuning run by job ID."""
@@ -216,29 +170,6 @@ async def delete_tuner_run(job_id: str, _: Annotated[HTTPBasicCredentials, Depen
 async def health_check() -> APIResponse:
     """Health check endpoint."""
     return APIResponse(success=True, data={"status": "ok"}, message="API is healthy")
-
-
-async def _list_jobs(statuses: list[str], key: str, message: str) -> APIResponse:
-    """List jobs by status."""
-    try:
-        jobs = await run_in_threadpool(get_jobs_by_status, statuses)
-    except OperationalError as e:
-        raise HTTPException(status_code=503, detail="Database is busy. Please try again later.") from e
-    return APIResponse(success=True, data={key: [j.job_id for j in jobs]}, message=message)
-
-
-@app.get("/api/tuner_runs")
-async def list_tuner_runs(_: Annotated[HTTPBasicCredentials, Depends(verify_credentials)]) -> APIResponse:
-    """List all active tuning runs (PENDING or RUNNING)."""
-    return await _list_jobs([JobStatus.PENDING.value, JobStatus.RUNNING.value], "active_jobs", "Active jobs listed")
-
-
-@app.get("/api/completed_jobs")
-async def list_completed_jobs(_: Annotated[HTTPBasicCredentials, Depends(verify_credentials)]) -> APIResponse:
-    """List all completed jobs from the database."""
-    return await _list_jobs(
-        [JobStatus.TERMINATED.value, JobStatus.ERROR.value], "completed_jobs", "Completed jobs listed"
-    )
 
 
 @app.get("/openapi.json", include_in_schema=False)

--- a/api/main.py
+++ b/api/main.py
@@ -110,7 +110,7 @@ async def get_status(job_id: str, _: Annotated[HTTPBasicCredentials, Depends(ver
 
         trials_dict = await run_in_threadpool(get_trials_by_job_id, job_id)
     except OperationalError as e:
-        logger.error("Database timeout for job %s: %s", job_id, e)
+        logger.exception("Database timeout for job %s", job_id)
         raise HTTPException(status_code=503, detail="Database is busy. Please try again later.") from e
 
     summary_counter = Counter(t.status for t in trials_dict.values())

--- a/api/main.py
+++ b/api/main.py
@@ -23,7 +23,6 @@ from api.db.operations import (
     get_job,
     get_jobs_by_status,
     get_trials_by_job_id,
-    get_trials_by_tpr_hash,
 )
 from api.rayworker import cancel_job, submit_tuning_job, sync_job_status
 from api.schemas import JobStatus, JobStatusResponse, TrialResponse
@@ -115,11 +114,7 @@ async def get_status(job_id: str, _: Annotated[HTTPBasicCredentials, Depends(ver
         if not job:
             raise HTTPException(status_code=404, detail=f"Job '{job_id}' not found")
 
-        trials_dict = (
-            await run_in_threadpool(get_trials_by_tpr_hash, job.tpr_hash)
-            if job.tpr_hash
-            else await run_in_threadpool(get_trials_by_job_id, job_id)
-        )
+        trials_dict = await run_in_threadpool(get_trials_by_job_id, job_id)
     except OperationalError as e:
         logger.error("Database timeout for job %s: %s", job_id, e)
         raise HTTPException(status_code=503, detail="Database is busy. Please try again later.") from e

--- a/api/main.py
+++ b/api/main.py
@@ -22,7 +22,7 @@ from api.db.operations import (
 )
 from api.rayworker import cancel_job, submit_tuning_job, sync_job_status
 from api.schemas import JobStatus, JobStatusResponse, TrialResponse
-from api.utils import cleanup_tmp_files, get_cluster_status, sanitize_extra_args
+from api.utils import cleanup_job_files, get_cluster_status, sanitize_extra_args
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +85,6 @@ async def create_tuner_run(
     except (ValidationError, ValueError) as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
-    cleanup_tmp_files(job_id)
     try:
         submit_tuning_job(job_id, type="standard", extra_args=sanitized_args, nsteps=nsteps)
     except Exception as e:
@@ -114,11 +113,10 @@ async def get_status(job_id: str, _: Annotated[HTTPBasicCredentials, Depends(ver
         raise HTTPException(status_code=503, detail="Database is busy. Please try again later.") from e
 
     summary_counter = Counter(t.status for t in trials_dict.values())
-    summary = {status.value: summary_counter.get(status.value, 0) for status in JobStatus}
+    summary = {status.value: summary_counter.get(status, 0) for status in JobStatus}
     trials = [
         TrialResponse(
-            id=tid,
-            trial_id=str(tid),
+            id=str(tid),
             status=t.status,
             ntomp=t.config.ntomp,
             np=t.config.np,
@@ -153,7 +151,7 @@ async def delete_tuner_run(job_id: str, _: Annotated[HTTPBasicCredentials, Depen
 
     cancelled = await run_in_threadpool(cancel_job, job_id)
     await run_in_threadpool(delete_job, job_id)
-    cleanup_tmp_files(job_id)
+    cleanup_job_files(job_id)
 
     logger.info("Deleted job %s: cancelled=%s", job_id, cancelled)
     return APIResponse(

--- a/api/main.py
+++ b/api/main.py
@@ -152,7 +152,7 @@ async def delete_tuner_run(job_id: str, _: Annotated[HTTPBasicCredentials, Depen
 
     cancelled = await run_in_threadpool(cancel_job, job_id)
     await run_in_threadpool(delete_job, job_id)
-    cleanup_job_files(job_id)
+    await run_in_threadpool(cleanup_job_files, job_id)
 
     logger.info("Deleted job %s: cancelled=%s", job_id, cancelled)
     return APIResponse(

--- a/api/rayworker/tuner.py
+++ b/api/rayworker/tuner.py
@@ -6,6 +6,7 @@ import uuid
 from typing import Any
 
 import ray
+from sqlalchemy import select
 
 from api.config import (
     EARLY_STOP_BASELINE_TRIALS,
@@ -14,11 +15,11 @@ from api.config import (
     RUNTIME_WORKDIR,
 )
 from api.db import init_db
+from api.db.models import Job, get_session
 from api.db.operations import (
     create_job,
     create_trial_result,
     get_job,
-    update_job_config,
     update_job_status,
     update_trial_result,
 )
@@ -109,7 +110,7 @@ def _submit_trials(
     best_steps_per_sec: float,
 ) -> dict[ray.ObjectRef, str]:
     """Submit a batch of trials to Ray and return futures map."""
-    future_to_hash: dict[ray.ObjectRef, str] = {}
+    future_to_trial: dict[ray.ObjectRef, str] = {}
     for trial_id, cfg, cfg_hash in trials:
         future = _run_single_trial.options(num_cpus=cfg.num_cpus, num_gpus=cfg.num_gpus).remote(
             job_id,
@@ -121,30 +122,30 @@ def _submit_trials(
             nsteps,  # type: ignore
             best_steps_per_sec,  # type: ignore
         )
-        future_to_hash[future] = cfg_hash
-        update_trial_result(cfg_hash, JobStatus.RUNNING, None)
-    return future_to_hash
+        future_to_trial[future] = trial_id
+        update_trial_result(trial_id, JobStatus.RUNNING, None)
+    return future_to_trial
 
 
 def _process_trial_results(
     job_id: str,
-    future_to_hash: dict[ray.ObjectRef, str],
+    future_to_trial: dict[ray.ObjectRef, str],
     best_steps_per_sec: float,
 ) -> float:
     """Wait for trials and update database results. Returns updated best_steps_per_sec."""
-    pending_futures = list(future_to_hash.keys())
+    pending_futures = list(future_to_trial.keys())
     new_best = best_steps_per_sec
 
     while pending_futures:
         done, pending_futures = ray.wait(pending_futures, num_returns=1)
-        cfg_hash = future_to_hash[done[0]]
+        trial_id = future_to_trial[done[0]]
         try:
             res: dict[str, Any] = ray.get(done[0])
             if res:
                 early_stopped = res.get("early_stopped", False)
                 perf_value = None if early_stopped else res.get("performance")
                 update_trial_result(
-                    res.get("cfg_hash", cfg_hash),
+                    res.get("trial_id", trial_id),
                     res.get("status", JobStatus.ERROR),
                     perf_value,
                 )
@@ -153,11 +154,11 @@ def _process_trial_results(
                     new_best = steps_per_sec
                     logger.info("Job %s: New best steps/sec: %.1f", job_id, new_best)
             else:
-                logger.warning("Trial with config %s returned no result", cfg_hash)
-                update_trial_result(cfg_hash, JobStatus.ERROR, None)
+                logger.warning("Trial %s returned no result", trial_id)
+                update_trial_result(trial_id, JobStatus.ERROR, None)
         except Exception as e:
-            logger.warning("Trial with config %s failed: %s", cfg_hash, e)
-            update_trial_result(cfg_hash, JobStatus.ERROR, None)
+            logger.warning("Trial %s failed: %s", trial_id, e)
+            update_trial_result(trial_id, JobStatus.ERROR, None)
 
     return new_best
 
@@ -167,7 +168,10 @@ def _run_tuning_async(job_id: str, tpr_path: str, extra_args: str = "", nsteps: 
     try:
         _ensure_ray_initialized()
         all_configs = TrialConfig.generate_all_configs()
-        update_job_config(job_id, len(all_configs))
+        with get_session() as session:
+            if job := session.execute(select(Job).where(Job.job_id == job_id)).scalar_one_or_none():
+                job.total_configs = len(all_configs)
+                session.commit()
         update_job_status(job_id, JobStatus.RUNNING)
 
         trial_configs: list[TrialConfigEntry] = []
@@ -184,14 +188,14 @@ def _run_tuning_async(job_id: str, tpr_path: str, extra_args: str = "", nsteps: 
         remaining_trials = trial_configs[baseline_count:]
 
         if baseline_trials:
-            future_to_hash = _submit_trials(job_id, tpr_path, extra_args, baseline_trials, nsteps, best_steps_per_sec)
-            best_steps_per_sec = _process_trial_results(job_id, future_to_hash, best_steps_per_sec)
+            future_to_trial = _submit_trials(job_id, tpr_path, extra_args, baseline_trials, nsteps, best_steps_per_sec)
+            best_steps_per_sec = _process_trial_results(job_id, future_to_trial, best_steps_per_sec)
 
         batch_size = max(1, EARLY_STOP_BATCH_SIZE)
         for idx in range(0, len(remaining_trials), batch_size):
             batch = remaining_trials[idx : idx + batch_size]
-            future_to_hash = _submit_trials(job_id, tpr_path, extra_args, batch, nsteps, best_steps_per_sec)
-            best_steps_per_sec = _process_trial_results(job_id, future_to_hash, best_steps_per_sec)
+            future_to_trial = _submit_trials(job_id, tpr_path, extra_args, batch, nsteps, best_steps_per_sec)
+            best_steps_per_sec = _process_trial_results(job_id, future_to_trial, best_steps_per_sec)
 
         logger.info("All trials completed for job %s (best: %.1f steps/s)", job_id, best_steps_per_sec)
         update_job_status(job_id, JobStatus.TERMINATED)

--- a/api/rayworker/tuner.py
+++ b/api/rayworker/tuner.py
@@ -198,9 +198,9 @@ def _run_tuning_async(job_id: str, extra_args: str = "", nsteps: int = 25_000) -
             _active_jobs.pop(job_id, None)
 
 
-def submit_tuning_job(job_id: str, type: str = "standard", extra_args: str = "", nsteps: int = 25_000) -> str:
+def submit_tuning_job(job_id: str, extra_args: str = "", nsteps: int = 25_000) -> str:
     """Submit a GROMACS tuning job."""
-    create_job(job_id, type, extra_args or None)
+    create_job(job_id)
     thread = threading.Thread(target=_run_tuning_async, args=(job_id, extra_args, nsteps), daemon=True)
     with _job_lock:
         _active_jobs[job_id] = thread

--- a/api/rayworker/tuner.py
+++ b/api/rayworker/tuner.py
@@ -5,7 +5,7 @@ import threading
 from typing import Any
 
 import ray
-from sqlalchemy import select
+from ray.exceptions import RayTaskError
 
 from api.config import (
     EARLY_STOP_BASELINE_TRIALS,
@@ -14,7 +14,6 @@ from api.config import (
     RUNTIME_WORKDIR,
 )
 from api.db import init_db
-from api.db.models import Job, get_session
 from api.db.operations import (
     create_job,
     create_trial_result,
@@ -148,7 +147,7 @@ def _process_trial_results(
             else:
                 logger.warning("Trial %d returned no result", trial_id)
                 update_trial_result(trial_id, JobStatus.ERROR, None)
-        except Exception as e:
+        except RayTaskError as e:
             logger.warning("Trial %d failed: %s", trial_id, e)
             update_trial_result(trial_id, JobStatus.ERROR, None)
 
@@ -160,10 +159,6 @@ def _run_tuning_async(job_id: str, extra_args: str = "", nsteps: int = 25_000) -
     try:
         _ensure_ray_initialized()
         all_configs = TrialConfig.generate_all_configs()
-        with get_session() as session:
-            if job := session.execute(select(Job).where(Job.id == job_id)).scalar_one_or_none():
-                job.total_configs = len(all_configs)
-                session.commit()
         update_job_status(job_id, JobStatus.RUNNING)
 
         trial_configs: list[TrialConfigEntry] = []

--- a/api/rayworker/tuner.py
+++ b/api/rayworker/tuner.py
@@ -35,8 +35,8 @@ logger.info("Tuner module initialized")
 _active_jobs: dict[str, threading.Thread] = {}
 _job_lock = threading.Lock()
 
-TrialConfigEntry = tuple[str, TrialConfig, str]
-"""Represents a queued trial: (trial_id, trial_config, config_hash)."""
+TrialConfigEntry = tuple[str, TrialConfig]
+"""Represents a queued trial: (trial_id, trial_config)."""
 
 
 def _ensure_ray_initialized() -> None:
@@ -52,7 +52,6 @@ def _run_single_trial(
     tpr_path: str,
     trial_id: str,
     config: TrialConfig,
-    cfg_hash: str,
     extra_args: str,
     nsteps: int = 25_000,
     best_steps_per_sec: float = 0.0,
@@ -81,8 +80,6 @@ def _run_single_trial(
     )
     return {
         "trial_id": trial_id,
-        "cfg_hash": cfg_hash,
-        "config": config.to_dict(),
         "status": status,
         "performance": performance,
         "steps_per_sec": steps_per_sec,
@@ -97,7 +94,7 @@ def _order_trial_configs(
     return sorted(
         trial_configs,
         # Sort descending by GPUs and CPUs to establish a high baseline early
-        key=lambda item: (-item[1].num_gpus, -item[1].num_cpus, item[2]),
+        key=lambda item: (-item[1].num_gpus, -item[1].num_cpus),
     )
 
 
@@ -111,13 +108,12 @@ def _submit_trials(
 ) -> dict[ray.ObjectRef, str]:
     """Submit a batch of trials to Ray and return futures map."""
     future_to_trial: dict[ray.ObjectRef, str] = {}
-    for trial_id, cfg, cfg_hash in trials:
+    for trial_id, cfg in trials:
         future = _run_single_trial.options(num_cpus=cfg.num_cpus, num_gpus=cfg.num_gpus).remote(
             job_id,
             tpr_path,
             trial_id,
             cfg,
-            cfg_hash,
             extra_args,
             nsteps,  # type: ignore
             best_steps_per_sec,  # type: ignore
@@ -177,8 +173,8 @@ def _run_tuning_async(job_id: str, tpr_path: str, extra_args: str = "", nsteps: 
         trial_configs: list[TrialConfigEntry] = []
         for cfg in all_configs:
             trial_id = str(uuid.uuid4())[:8]
-            create_trial_result(job_id, trial_id, cfg, cfg.hash, JobStatus.PENDING, None)
-            trial_configs.append((trial_id, cfg, cfg.hash))
+            create_trial_result(job_id, trial_id, cfg, JobStatus.PENDING, None)
+            trial_configs.append((trial_id, cfg))
 
         trial_configs = _order_trial_configs(trial_configs)
         best_steps_per_sec = 0.0

--- a/api/rayworker/tuner.py
+++ b/api/rayworker/tuner.py
@@ -219,7 +219,7 @@ def cancel_job(job_id: str) -> bool:
     return True
 
 
-def sync_job_status(job_id: str) -> str | None:
+def sync_job_status(job_id: str) -> JobStatus | None:
     """Sync job status - checks if background thread is still running."""
     job = get_job(job_id)
     if not job:

--- a/api/rayworker/tuner.py
+++ b/api/rayworker/tuner.py
@@ -5,7 +5,7 @@ import threading
 from typing import Any
 
 import ray
-from ray.exceptions import RayTaskError
+from ray.exceptions import RayError
 
 from api.config import (
     EARLY_STOP_BASELINE_TRIALS,
@@ -30,8 +30,81 @@ logger = logging.getLogger(__name__)
 init_db()
 logger.info("Tuner module initialized")
 
-_active_jobs: dict[str, threading.Thread] = {}
-_job_lock = threading.Lock()
+
+class JobState:
+    """Encapsulates state for a single running job."""
+
+    def __init__(self, thread: threading.Thread) -> None:
+        """Initialize job state with its background thread."""
+        self.thread = thread
+        self.cancelled = threading.Event()
+        self.futures: set[ray.ObjectRef] = set()
+
+
+class JobContext:
+    """Manages active job state with thread-safe operations."""
+
+    def __init__(self) -> None:
+        """Initialize the job context manager."""
+        self._jobs: dict[str, JobState] = {}
+        self._lock = threading.Lock()
+
+    def add_job(self, job_id: str, thread: threading.Thread) -> None:
+        """Add a new job to the context."""
+        with self._lock:
+            self._jobs[job_id] = JobState(thread)
+
+    def remove_job(self, job_id: str) -> None:
+        """Remove a job from the context."""
+        with self._lock:
+            self._jobs.pop(job_id, None)
+
+    def is_cancelled(self, job_id: str) -> bool:
+        """Check if a job has been cancelled."""
+        with self._lock:
+            state = self._jobs.get(job_id)
+            return state is not None and state.cancelled.is_set()
+
+    def mark_cancelled(self, job_id: str) -> threading.Event:
+        """Mark a job as cancelled."""
+        with self._lock:
+            state = self._jobs.get(job_id)
+            if state:
+                state.cancelled.set()
+                return state.cancelled
+            # Job might have already finished, create event anyway
+            event = threading.Event()
+            event.set()
+            return event
+
+    def add_futures(self, job_id: str, futures: set[ray.ObjectRef]) -> None:
+        """Add Ray futures to a job's tracking set."""
+        with self._lock:
+            state = self._jobs.get(job_id)
+            if state:
+                state.futures.update(futures)
+
+    def remove_future(self, job_id: str, future: ray.ObjectRef) -> None:
+        """Remove a completed future from a job's tracking set."""
+        with self._lock:
+            state = self._jobs.get(job_id)
+            if state:
+                state.futures.discard(future)
+
+    def get_futures(self, job_id: str) -> set[ray.ObjectRef]:
+        """Get a copy of all active futures for a job."""
+        with self._lock:
+            state = self._jobs.get(job_id)
+            return state.futures.copy() if state else set()
+
+    def is_thread_alive(self, job_id: str) -> bool:
+        """Check if a job's background thread is still running."""
+        with self._lock:
+            state = self._jobs.get(job_id)
+            return state is not None and state.thread.is_alive()
+
+
+_job_context = JobContext()
 
 TrialConfigEntry = tuple[int, TrialConfig]
 """Represents a queued trial: (trial_id, trial_config)."""
@@ -115,6 +188,10 @@ def _submit_trials(
         )
         future_to_trial[future] = trial_id
         update_trial_result(trial_id, JobStatus.RUNNING, None)
+
+    # Track active futures for cancellation
+    _job_context.add_futures(job_id, set(future_to_trial.keys()))
+
     return future_to_trial
 
 
@@ -147,9 +224,12 @@ def _process_trial_results(
             else:
                 logger.warning("Trial %d returned no result", trial_id)
                 update_trial_result(trial_id, JobStatus.ERROR, None)
-        except RayTaskError as e:
+        except RayError as e:
             logger.warning("Trial %d failed: %s", trial_id, e)
             update_trial_result(trial_id, JobStatus.ERROR, None)
+        finally:
+            # Remove completed future from active set
+            _job_context.remove_future(job_id, done[0])
 
     return new_best
 
@@ -161,10 +241,7 @@ def _run_tuning_async(job_id: str, extra_args: str = "", nsteps: int = 25_000) -
         all_configs = TrialConfig.generate_all_configs()
         update_job_status(job_id, JobStatus.RUNNING)
 
-        trial_configs: list[TrialConfigEntry] = []
-        for cfg in all_configs:
-            trial_id = create_trial_result(job_id, cfg, JobStatus.PENDING, None)
-            trial_configs.append((trial_id, cfg))
+        trial_configs = [(create_trial_result(job_id, cfg, JobStatus.PENDING, None), cfg) for cfg in all_configs]
 
         trial_configs = _order_trial_configs(trial_configs)
         best_steps_per_sec = 0.0
@@ -179,6 +256,9 @@ def _run_tuning_async(job_id: str, extra_args: str = "", nsteps: int = 25_000) -
 
         batch_size = max(1, EARLY_STOP_BATCH_SIZE)
         for idx in range(0, len(remaining_trials), batch_size):
+            if _job_context.is_cancelled(job_id):
+                logger.info("Job %s cancelled, skipping remaining trials", job_id)
+                break
             batch = remaining_trials[idx : idx + batch_size]
             future_to_trial = _submit_trials(job_id, extra_args, batch, nsteps, best_steps_per_sec)
             best_steps_per_sec = _process_trial_results(job_id, future_to_trial, best_steps_per_sec)
@@ -189,16 +269,14 @@ def _run_tuning_async(job_id: str, extra_args: str = "", nsteps: int = 25_000) -
         logger.exception("Tuning job %s failed", job_id)
         update_job_status(job_id, JobStatus.ERROR, str(e))
     finally:
-        with _job_lock:
-            _active_jobs.pop(job_id, None)
+        _job_context.remove_job(job_id)
 
 
 def submit_tuning_job(job_id: str, extra_args: str = "", nsteps: int = 25_000) -> str:
     """Submit a GROMACS tuning job."""
     create_job(job_id)
     thread = threading.Thread(target=_run_tuning_async, args=(job_id, extra_args, nsteps), daemon=True)
-    with _job_lock:
-        _active_jobs[job_id] = thread
+    _job_context.add_job(job_id, thread)
     thread.start()
     logger.info("Submitted tuning job %s", job_id)
     return job_id
@@ -209,6 +287,21 @@ def cancel_job(job_id: str) -> bool:
     if not get_job(job_id):
         logger.warning("Cannot cancel: job %s not found", job_id)
         return False
+
+    # Set cancellation flag to prevent new trials from being submitted
+    _job_context.mark_cancelled(job_id)
+
+    # Cancel any actively running Ray tasks
+    futures_to_cancel = _job_context.get_futures(job_id)
+
+    if futures_to_cancel:
+        logger.info("Cancelling %d active trials for job %s", len(futures_to_cancel), job_id)
+        for future in futures_to_cancel:
+            try:
+                ray.cancel(future, force=False)
+            except Exception as e:
+                logger.warning("Failed to cancel trial for job %s: %s", job_id, e)
+
     update_job_status(job_id, JobStatus.ERROR, "Cancelled by user")
     logger.info("Marked job %s as cancelled", job_id)
     return True
@@ -223,10 +316,11 @@ def sync_job_status(job_id: str) -> JobStatus | None:
     if job.status in (JobStatus.TERMINATED, JobStatus.ERROR):
         return job.status
 
-    with _job_lock:
-        thread = _active_jobs.get(job_id)
-        if thread and thread.is_alive():
-            return JobStatus.RUNNING
+    if _job_context.is_cancelled(job_id):
+        return JobStatus.ERROR
+
+    if _job_context.is_thread_alive(job_id):
+        return JobStatus.RUNNING
 
     if job.status == JobStatus.RUNNING:
         update_job_status(job_id, JobStatus.ERROR, "Job thread terminated unexpectedly")

--- a/api/rayworker/tuner.py
+++ b/api/rayworker/tuner.py
@@ -115,8 +115,8 @@ def _submit_trials(
             trial_id,
             cfg,
             extra_args,
-            nsteps,  # type: ignore
-            best_steps_per_sec,  # type: ignore
+            nsteps,  # type: ignore[arg-type]
+            best_steps_per_sec,
         )
         future_to_trial[future] = trial_id
         update_trial_result(trial_id, JobStatus.RUNNING, None)

--- a/api/rayworker/tuner.py
+++ b/api/rayworker/tuner.py
@@ -17,7 +17,6 @@ from api.db import init_db
 from api.db.operations import (
     create_job,
     create_trial_result,
-    get_completed_config_hashes,
     get_job,
     update_job_config,
     update_job_status,
@@ -25,7 +24,6 @@ from api.db.operations import (
 )
 from api.gromacs import TrialConfig, run_mdrun
 from api.schemas import JobStatus
-from api.utils import sha256_of_file
 
 RAY_RUNTIME_ENV = {"working_dir": RUNTIME_WORKDIR}
 logger = logging.getLogger(__name__)
@@ -106,7 +104,6 @@ def _submit_trials(
     job_id: str,
     tpr_path: str,
     extra_args: str,
-    tpr_hash: str,
     trials: list[TrialConfigEntry],
     nsteps: int,
     best_steps_per_sec: float,
@@ -125,13 +122,12 @@ def _submit_trials(
             best_steps_per_sec,  # type: ignore
         )
         future_to_hash[future] = cfg_hash
-        update_trial_result(tpr_hash, cfg_hash, JobStatus.RUNNING, None)
+        update_trial_result(cfg_hash, JobStatus.RUNNING, None)
     return future_to_hash
 
 
 def _process_trial_results(
     job_id: str,
-    tpr_hash: str,
     future_to_hash: dict[ray.ObjectRef, str],
     best_steps_per_sec: float,
 ) -> float:
@@ -148,7 +144,6 @@ def _process_trial_results(
                 early_stopped = res.get("early_stopped", False)
                 perf_value = None if early_stopped else res.get("performance")
                 update_trial_result(
-                    tpr_hash,
                     res.get("cfg_hash", cfg_hash),
                     res.get("status", JobStatus.ERROR),
                     perf_value,
@@ -159,10 +154,10 @@ def _process_trial_results(
                     logger.info("Job %s: New best steps/sec: %.1f", job_id, new_best)
             else:
                 logger.warning("Trial with config %s returned no result", cfg_hash)
-                update_trial_result(tpr_hash, cfg_hash, JobStatus.ERROR, None)
+                update_trial_result(cfg_hash, JobStatus.ERROR, None)
         except Exception as e:
             logger.warning("Trial with config %s failed: %s", cfg_hash, e)
-            update_trial_result(tpr_hash, cfg_hash, JobStatus.ERROR, None)
+            update_trial_result(cfg_hash, JobStatus.ERROR, None)
 
     return new_best
 
@@ -171,23 +166,15 @@ def _run_tuning_async(job_id: str, tpr_path: str, extra_args: str = "", nsteps: 
     """Run grid search tuning in a background thread with early stopping support."""
     try:
         _ensure_ray_initialized()
-        tpr_hash = sha256_of_file(tpr_path)
         all_configs = TrialConfig.generate_all_configs()
-        completed_hashes = get_completed_config_hashes(tpr_hash)
-        update_job_config(job_id, tpr_hash, len(all_configs))
+        update_job_config(job_id, len(all_configs))
         update_job_status(job_id, JobStatus.RUNNING)
 
-        pending_configs = [(cfg, cfg.hash) for cfg in all_configs if cfg.hash not in completed_hashes]
-        if not pending_configs:
-            logger.info("All configs already cached for job %s", job_id)
-            update_job_status(job_id, JobStatus.TERMINATED)
-            return
-
         trial_configs: list[TrialConfigEntry] = []
-        for cfg, cfg_hash in pending_configs:
+        for cfg in all_configs:
             trial_id = str(uuid.uuid4())[:8]
-            create_trial_result(job_id, trial_id, tpr_hash, cfg, cfg_hash, JobStatus.PENDING, None)
-            trial_configs.append((trial_id, cfg, cfg_hash))
+            create_trial_result(job_id, trial_id, cfg, cfg.hash, JobStatus.PENDING, None)
+            trial_configs.append((trial_id, cfg, cfg.hash))
 
         trial_configs = _order_trial_configs(trial_configs)
         best_steps_per_sec = 0.0
@@ -197,16 +184,14 @@ def _run_tuning_async(job_id: str, tpr_path: str, extra_args: str = "", nsteps: 
         remaining_trials = trial_configs[baseline_count:]
 
         if baseline_trials:
-            future_to_hash = _submit_trials(
-                job_id, tpr_path, extra_args, tpr_hash, baseline_trials, nsteps, best_steps_per_sec
-            )
-            best_steps_per_sec = _process_trial_results(job_id, tpr_hash, future_to_hash, best_steps_per_sec)
+            future_to_hash = _submit_trials(job_id, tpr_path, extra_args, baseline_trials, nsteps, best_steps_per_sec)
+            best_steps_per_sec = _process_trial_results(job_id, future_to_hash, best_steps_per_sec)
 
         batch_size = max(1, EARLY_STOP_BATCH_SIZE)
         for idx in range(0, len(remaining_trials), batch_size):
             batch = remaining_trials[idx : idx + batch_size]
-            future_to_hash = _submit_trials(job_id, tpr_path, extra_args, tpr_hash, batch, nsteps, best_steps_per_sec)
-            best_steps_per_sec = _process_trial_results(job_id, tpr_hash, future_to_hash, best_steps_per_sec)
+            future_to_hash = _submit_trials(job_id, tpr_path, extra_args, batch, nsteps, best_steps_per_sec)
+            best_steps_per_sec = _process_trial_results(job_id, future_to_hash, best_steps_per_sec)
 
         logger.info("All trials completed for job %s (best: %.1f steps/s)", job_id, best_steps_per_sec)
         update_job_status(job_id, JobStatus.TERMINATED)

--- a/api/rayworker/tuner.py
+++ b/api/rayworker/tuner.py
@@ -2,7 +2,6 @@
 
 import logging
 import threading
-import uuid
 from typing import Any
 
 import ray
@@ -35,7 +34,7 @@ logger.info("Tuner module initialized")
 _active_jobs: dict[str, threading.Thread] = {}
 _job_lock = threading.Lock()
 
-TrialConfigEntry = tuple[str, TrialConfig]
+TrialConfigEntry = tuple[int, TrialConfig]
 """Represents a queued trial: (trial_id, trial_config)."""
 
 
@@ -49,7 +48,6 @@ def _ensure_ray_initialized() -> None:
 @ray.remote(max_retries=3)
 def _run_single_trial(
     job_id: str,
-    tpr_path: str,
     trial_id: str,
     config: TrialConfig,
     extra_args: str,
@@ -68,7 +66,7 @@ def _run_single_trial(
         best_steps_per_sec,
     )
     performance, steps_per_sec, early_stopped = run_mdrun(
-        config, tpr_path, trial_id, job_id, extra_args, nsteps, best_steps_per_sec
+        config, trial_id, job_id, extra_args, nsteps, best_steps_per_sec
     )
     status = JobStatus.TERMINATED if performance > 0 or early_stopped else JobStatus.ERROR
     logger.info(
@@ -100,19 +98,17 @@ def _order_trial_configs(
 
 def _submit_trials(
     job_id: str,
-    tpr_path: str,
     extra_args: str,
     trials: list[TrialConfigEntry],
     nsteps: int,
     best_steps_per_sec: float,
-) -> dict[ray.ObjectRef, str]:
+) -> dict[ray.ObjectRef, int]:
     """Submit a batch of trials to Ray and return futures map."""
-    future_to_trial: dict[ray.ObjectRef, str] = {}
+    future_to_trial: dict[ray.ObjectRef, int] = {}
     for trial_id, cfg in trials:
         future = _run_single_trial.options(num_cpus=cfg.num_cpus, num_gpus=cfg.num_gpus).remote(
             job_id,
-            tpr_path,
-            trial_id,
+            str(trial_id),
             cfg,
             extra_args,
             nsteps,  # type: ignore[arg-type]
@@ -125,7 +121,7 @@ def _submit_trials(
 
 def _process_trial_results(
     job_id: str,
-    future_to_trial: dict[ray.ObjectRef, str],
+    future_to_trial: dict[ray.ObjectRef, int],
     best_steps_per_sec: float,
 ) -> float:
     """Wait for trials and update database results. Returns updated best_steps_per_sec."""
@@ -141,7 +137,7 @@ def _process_trial_results(
                 early_stopped = res.get("early_stopped", False)
                 perf_value = None if early_stopped else res.get("performance")
                 update_trial_result(
-                    res.get("trial_id", trial_id),
+                    trial_id,
                     res.get("status", JobStatus.ERROR),
                     perf_value,
                 )
@@ -150,30 +146,29 @@ def _process_trial_results(
                     new_best = steps_per_sec
                     logger.info("Job %s: New best steps/sec: %.1f", job_id, new_best)
             else:
-                logger.warning("Trial %s returned no result", trial_id)
+                logger.warning("Trial %d returned no result", trial_id)
                 update_trial_result(trial_id, JobStatus.ERROR, None)
         except Exception as e:
-            logger.warning("Trial %s failed: %s", trial_id, e)
+            logger.warning("Trial %d failed: %s", trial_id, e)
             update_trial_result(trial_id, JobStatus.ERROR, None)
 
     return new_best
 
 
-def _run_tuning_async(job_id: str, tpr_path: str, extra_args: str = "", nsteps: int = 25_000) -> None:
+def _run_tuning_async(job_id: str, extra_args: str = "", nsteps: int = 25_000) -> None:
     """Run grid search tuning in a background thread with early stopping support."""
     try:
         _ensure_ray_initialized()
         all_configs = TrialConfig.generate_all_configs()
         with get_session() as session:
-            if job := session.execute(select(Job).where(Job.job_id == job_id)).scalar_one_or_none():
+            if job := session.execute(select(Job).where(Job.id == job_id)).scalar_one_or_none():
                 job.total_configs = len(all_configs)
                 session.commit()
         update_job_status(job_id, JobStatus.RUNNING)
 
         trial_configs: list[TrialConfigEntry] = []
         for cfg in all_configs:
-            trial_id = str(uuid.uuid4())[:8]
-            create_trial_result(job_id, trial_id, cfg, JobStatus.PENDING, None)
+            trial_id = create_trial_result(job_id, cfg, JobStatus.PENDING, None)
             trial_configs.append((trial_id, cfg))
 
         trial_configs = _order_trial_configs(trial_configs)
@@ -184,13 +179,13 @@ def _run_tuning_async(job_id: str, tpr_path: str, extra_args: str = "", nsteps: 
         remaining_trials = trial_configs[baseline_count:]
 
         if baseline_trials:
-            future_to_trial = _submit_trials(job_id, tpr_path, extra_args, baseline_trials, nsteps, best_steps_per_sec)
+            future_to_trial = _submit_trials(job_id, extra_args, baseline_trials, nsteps, best_steps_per_sec)
             best_steps_per_sec = _process_trial_results(job_id, future_to_trial, best_steps_per_sec)
 
         batch_size = max(1, EARLY_STOP_BATCH_SIZE)
         for idx in range(0, len(remaining_trials), batch_size):
             batch = remaining_trials[idx : idx + batch_size]
-            future_to_trial = _submit_trials(job_id, tpr_path, extra_args, batch, nsteps, best_steps_per_sec)
+            future_to_trial = _submit_trials(job_id, extra_args, batch, nsteps, best_steps_per_sec)
             best_steps_per_sec = _process_trial_results(job_id, future_to_trial, best_steps_per_sec)
 
         logger.info("All trials completed for job %s (best: %.1f steps/s)", job_id, best_steps_per_sec)
@@ -203,12 +198,10 @@ def _run_tuning_async(job_id: str, tpr_path: str, extra_args: str = "", nsteps: 
             _active_jobs.pop(job_id, None)
 
 
-def submit_tuning_job(
-    job_id: str, tpr_path: str, job_type: str = "standard", extra_args: str = "", nsteps: int = 25_000
-) -> str:
+def submit_tuning_job(job_id: str, type: str = "standard", extra_args: str = "", nsteps: int = 25_000) -> str:
     """Submit a GROMACS tuning job."""
-    create_job(job_id, job_type, tpr_path, extra_args or None)
-    thread = threading.Thread(target=_run_tuning_async, args=(job_id, tpr_path, extra_args, nsteps), daemon=True)
+    create_job(job_id, type, extra_args or None)
+    thread = threading.Thread(target=_run_tuning_async, args=(job_id, extra_args, nsteps), daemon=True)
     with _job_lock:
         _active_jobs[job_id] = thread
     thread.start()

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -22,7 +22,7 @@ class TrialInfo:
     """Information about a single trial."""
 
     config: TrialConfig
-    status: str
+    status: JobStatus
     performance: float | None = None
 
 
@@ -30,9 +30,8 @@ class TrialInfo:
 class TrialResponse:
     """Trial data for API responses."""
 
-    id: int
-    trial_id: str
-    status: str
+    id: str
+    status: JobStatus
     ntomp: int
     np: int
     nb: str
@@ -46,7 +45,7 @@ class JobStatusResponse:
     """Job status response for API."""
 
     id: str
-    status: str
+    status: JobStatus
     summary: dict[str, int]
     trials: list[TrialResponse]
     cluster_resources: str

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -1,6 +1,6 @@
 """Common types and enums for the GROMACS tuner API."""
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
@@ -24,16 +24,6 @@ class TrialInfo:
     config: TrialConfig
     status: str
     performance: float | None = None
-
-
-@dataclass
-class JobInfo:
-    """Information about a tuning job."""
-
-    total: int
-    status: str = JobStatus.RUNNING
-    trials: dict[str, TrialInfo] = field(default_factory=dict)
-    error: str | None = None
 
 
 @dataclass

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -30,7 +30,6 @@ class TrialInfo:
 class JobInfo:
     """Information about a tuning job."""
 
-    tpr_hash: str
     total: int
     status: str = JobStatus.RUNNING
     trials: dict[str, TrialInfo] = field(default_factory=dict)

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -30,7 +30,8 @@ class TrialInfo:
 class TrialResponse:
     """Trial data for API responses."""
 
-    id: str
+    id: int
+    trial_id: str
     status: str
     ntomp: int
     np: int
@@ -44,8 +45,8 @@ class TrialResponse:
 class JobStatusResponse:
     """Job status response for API."""
 
-    tuner_run_id: str
-    job_status: str
+    id: str
+    status: str
     summary: dict[str, int]
     trials: list[TrialResponse]
     cluster_resources: str
@@ -54,8 +55,8 @@ class JobStatusResponse:
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for API response."""
         result = {
-            "tuner_run_id": self.tuner_run_id,
-            "status": self.job_status,
+            "id": self.id,
+            "status": self.status,
             "summary": self.summary,
             "trials": [vars(t) for t in self.trials],
             "cluster_resources": self.cluster_resources,

--- a/api/utils.py
+++ b/api/utils.py
@@ -26,17 +26,16 @@ _EXTRA_ARGS_FORBIDDEN_FLAGS = {"-deffnm", "-s", "-nsteps", "-ntomp", "-np", "-nb
 
 def cleanup_tmp_files(job_id: str, directory: Path = TPR_DIR) -> None:
     """Remove temporary files associated with a job ID."""
-    for path in directory.glob(f"{job_id}*"):
+    # Remove TPR file
+    tpr_file = directory / f"{job_id}_md.tpr"
+    if tpr_file.exists():
         try:
-            is_dir = path.is_dir()
-            if is_dir:
-                shutil.rmtree(path)
-            else:
-                path.unlink()
-            logger.info("Deleted %s: %s", "directory" if is_dir else "file", path)
+            tpr_file.unlink()
+            logger.info("Deleted TPR file: %s", tpr_file)
         except OSError:
-            logger.exception("Failed to delete %s", path)
+            logger.exception("Failed to delete %s", tpr_file)
 
+    # Remove trial directory
     trial_job_dir = JOBS_DIR / job_id
     if trial_job_dir.is_dir():
         try:
@@ -92,27 +91,35 @@ def get_cluster_status() -> str:
 
 
 def tail(file: Path | str, n: int = 10) -> str:
-    """Read last n lines of a file efficiently."""
+    """
+    Read last n lines of a file efficiently.
+
+    Returns empty string if file doesn't exist.
+    """
     file_path = Path(file) if isinstance(file, str) else file
-    with file_path.open("rb") as f:
-        f.seek(0, os.SEEK_END)
-        file_size = f.tell()
-        if file_size == 0:
-            return ""
+    try:
+        with file_path.open("rb") as f:
+            f.seek(0, os.SEEK_END)
+            file_size = f.tell()
+            if file_size == 0:
+                return ""
 
-        lines_found: deque[bytes] = deque()
-        pos = file_size
-        while pos > 0 and len(lines_found) < n:
-            chunk_start = max(0, pos - 8192)
-            f.seek(chunk_start)
-            chunk = f.read(pos - chunk_start)
-            chunk_lines = chunk.split(b"\n")
-            if lines_found and chunk_lines:
-                lines_found[0] = chunk_lines.pop() + lines_found[0]
-            lines_found.extendleft(reversed(chunk_lines))
-            pos = chunk_start
+            lines_found: deque[bytes] = deque()
+            pos = file_size
+            while pos > 0 and len(lines_found) < n:
+                chunk_start = max(0, pos - 8192)
+                f.seek(chunk_start)
+                chunk = f.read(pos - chunk_start)
+                chunk_lines = chunk.split(b"\n")
+                if lines_found and chunk_lines:
+                    lines_found[0] = chunk_lines.pop() + lines_found[0]
+                lines_found.extendleft(reversed(chunk_lines))
+                pos = chunk_start
 
-        return b"\n".join(list(lines_found)[-n:]).decode("utf-8", "replace")
+            return b"\n".join(list(lines_found)[-n:]).decode("utf-8", "replace")
+    except FileNotFoundError:
+        logger.debug("File not found: %s", file_path)
+        return ""
 
 
 def sanitize_extra_args(extra_args: str) -> str:

--- a/api/utils.py
+++ b/api/utils.py
@@ -24,10 +24,10 @@ _EXTRA_ARGS_FORBIDDEN_RE = re.compile(r"[;&|`$()<>]")
 _EXTRA_ARGS_FORBIDDEN_FLAGS = {"-deffnm", "-s", "-nsteps", "-ntomp", "-np", "-nb", "-pme"}
 
 
-def cleanup_tmp_files(job_id: str, directory: Path = TPR_DIR) -> None:
+def cleanup_job_files(job_id: str) -> None:
     """Remove temporary files associated with a job ID."""
     # Remove TPR file
-    tpr_file = directory / f"{job_id}_md.tpr"
+    tpr_file = TPR_DIR / f"{job_id}_md.tpr"
     if tpr_file.exists():
         try:
             tpr_file.unlink()

--- a/openapi/gromacs-tuner-openapi.yaml
+++ b/openapi/gromacs-tuner-openapi.yaml
@@ -12,17 +12,6 @@ security:
 
 paths:
   /tuner_runs:
-    get:
-      summary: List active tuner jobs.
-      security:
-        - basicAuth: []
-      responses:
-        "200":
-          description: Active jobs listed.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SuccessResponseWithActive"
     post:
       summary: Submit a `.tpr` file for tuning.
       description: Uploads a `.tpr` file and starts a tuning process.
@@ -100,51 +89,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SuccessResponseWithStatus"
-
-  /custom_run:
-    post:
-      summary: Submit a ZIP job with custom args.
-      security:
-        - basicAuth: []
-      requestBody:
-        required: true
-        content:
-          multipart/form-data:
-            schema:
-              type: object
-              properties:
-                file:
-                  type: string
-                  format: binary
-                  description: A `.zip` file with a `md.tpr` file and optionally other files.
-                extra_args:
-                  type: string
-                  default: ""
-                  example: "-plumed plumed.dat"
-                  description: |
-                    Additional GROMACS mdrun arguments.
-                    Shell metacharacters (; & | ` $ ( ) < >) are forbidden.
-                    Critical flags (-deffnm, -s, -nsteps, -ntomp, -np, -nb, -pme) cannot be overridden.
-      responses:
-        "200":
-          description: Custom tuning job started.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SuccessResponseWithRunID"
-
-  /completed_jobs:
-    get:
-      summary: List all completed jobs.
-      security:
-        - basicAuth: []
-      responses:
-        "200":
-          description: Completed jobs listed.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SuccessResponseWithCompleted"
 
   /health:
     get:
@@ -262,42 +206,6 @@ components:
               type: integer
             cancelled:
               type: boolean
-        message:
-          type: string
-        error:
-          type: object
-          nullable: true
-
-    SuccessResponseWithActive:
-      type: object
-      properties:
-        success:
-          type: boolean
-        data:
-          type: object
-          properties:
-            active_jobs:
-              type: array
-              items:
-                type: string
-        message:
-          type: string
-        error:
-          type: object
-          nullable: true
-
-    SuccessResponseWithCompleted:
-      type: object
-      properties:
-        success:
-          type: boolean
-        data:
-          type: object
-          properties:
-            completed_jobs:
-              type: array
-              items:
-                type: string
         message:
           type: string
         error:

--- a/openapi/gromacs-tuner-openapi.yaml
+++ b/openapi/gromacs-tuner-openapi.yaml
@@ -116,7 +116,7 @@ components:
         data:
           type: object
           properties:
-            tuner_run_id:
+            id:
               type: string
             status:
               type: string
@@ -134,7 +134,7 @@ components:
         data:
           type: object
           properties:
-            tuner_run_id:
+            id:
               type: string
             status:
               type: string
@@ -200,10 +200,8 @@ components:
         data:
           type: object
           properties:
-            tuner_run_id:
+            id:
               type: string
-            deleted_db_rows:
-              type: integer
             cancelled:
               type: boolean
         message:

--- a/testing_sh/endpoint_check.sh
+++ b/testing_sh/endpoint_check.sh
@@ -5,7 +5,5 @@ AUTH="admin:strong-secret-here"
 JOB_ID="e9573405-abab-46e5-ba17-2c2fa7d6f8e6"
 
 curl -s -u $AUTH "$BASE_URL/health" | jq .
-curl -s -u $AUTH "$BASE_URL/tuner_runs" | jq .
-curl -s -u $AUTH "$BASE_URL/completed_jobs" | jq .
 curl -s -u $AUTH "$BASE_URL/tuner_runs/$JOB_ID/status" | jq .
 curl -s -u $AUTH -X DELETE "$BASE_URL/tuner_runs/$JOB_ID" | jq .

--- a/testing_sh/run_submit.sh
+++ b/testing_sh/run_submit.sh
@@ -6,51 +6,31 @@ AUTH="admin:strong-secret-here"
 
 # Usage info
 usage() {
-  echo "Usage: $0 [--replica zipfile] [--plumed zipfile] [--tpr tprfile]"
+  echo "Usage: $0 [--tpr tprfile] [--extra-args args]"
   exit 1
 }
 
-if [ "$1" = "--replica" ] && [ -n "$2" ]; then
-  ZIPFILE="$2"
-  if [ ! -f "$ZIPFILE" ]; then
-    echo "Error: File '$ZIPFILE' not found."
-    exit 1
-  fi
-  echo "Submitting replica exchange ZIP to $API_BASE/replica_exchange..."
-  response=$(curl -s -u "$AUTH" -X POST -F "file=@${ZIPFILE}" "$API_BASE/replica_exchange")
-  echo "Replica Exchange Submission Response:"
-  echo "$response"
-  exit 0
-
-elif [ "$1" = "--plumed" ] && [ -n "$2" ]; then
-  ZIPFILE="$2"
-  if [ ! -f "$ZIPFILE" ]; then
-    echo "Error: File '$ZIPFILE' not found."
-    exit 1
-  fi
-  # Allow extra arguments to be passed after the zipfile
-  shift 2
-  EXTRA_ARGS="-deffnm md -plumed plumed.dat"
-  if [ $# -gt 0 ]; then
-    EXTRA_ARGS="$EXTRA_ARGS $*"
-  fi
-  echo "Submitting plumed job ZIP to $API_BASE/custom_run..."
-  response=$(curl -s -u "$AUTH" -X POST \
-    -F "file=@${ZIPFILE}" \
-    -F "extra_args=${EXTRA_ARGS}" \
-    "$API_BASE/custom_run")
-  echo "Plumed Submission Response:"
-  echo "$response"
-  exit 0
-
-elif [ "$1" = "--tpr" ] && [ -n "$2" ]; then
+if [ "$1" = "--tpr" ] && [ -n "$2" ]; then
   FILE="$2"
   if [ ! -f "$FILE" ]; then
     echo "Error: File '$FILE' not found."
     exit 1
   fi
+  # Allow extra arguments to be passed after the tprfile
+  shift 2
+  EXTRA_ARGS=""
+  if [ $# -gt 0 ]; then
+    EXTRA_ARGS="$*"
+  fi
   echo "Submitting $FILE to $API_BASE/tuner_runs..."
-  response=$(curl -s -u "$AUTH" -X POST -F "file=@${FILE}" "$API_BASE/tuner_runs")
+  if [ -n "$EXTRA_ARGS" ]; then
+    response=$(curl -s -u "$AUTH" -X POST \
+      -F "file=@${FILE}" \
+      -F "extra_args=${EXTRA_ARGS}" \
+      "$API_BASE/tuner_runs")
+  else
+    response=$(curl -s -u "$AUTH" -X POST -F "file=@${FILE}" "$API_BASE/tuner_runs")
+  fi
   echo "Tuning Submission Response:"
   echo "$response"
   exit 0

--- a/testing_sh/run_submit.sh
+++ b/testing_sh/run_submit.sh
@@ -6,7 +6,7 @@ AUTH="admin:strong-secret-here"
 
 # Usage info
 usage() {
-  echo "Usage: $0 [--tpr tprfile] [--extra-args args]"
+  echo "Usage: $0 --tpr tprfile [extra args...]"
   exit 1
 }
 


### PR DESCRIPTION
Removed `tpr_hash` because the caching mechanism was unnecessary. Removed `config_hash` because it was unnecessary. Removed redundadn and unwanted API endpoints. Refactored existing code and removed dead code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Removed Features**
  * Removed POST /api/custom_run, GET /api/tuner_runs, and GET /api/completed_jobs endpoints.
  * Removed previous job-level aggregation/listing schema.

* **Changes**
  * APIs now use a single string job ID and numeric trial IDs in responses.
  * Status values standardized to an enum; status payloads include an optional error field.
  * Trial responses include richer fields: type, pme, performance.
  * CLI submission simplified to --tpr <file> with optional extra_args; legacy flags removed.
  * File handling and cleanup made safer; deletion responses simplified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->