### PR TITLE
Add separate cluster resources endpoint and remove summary from tuner_runs endpoint

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -2,6 +2,7 @@ import logging
 import secrets
 import shutil
 import uuid
+from dataclasses import asdict
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -127,12 +128,14 @@ async def get_status(job_id: str, _: Annotated[HTTPBasicCredentials, Depends(ver
 
     return APIResponse(
         success=True,
-        data=JobStatusResponse(
-            id=job_id,
-            status=job.status,
-            trials=trials,
-            error=job.error,
-        ).to_dict(),
+        data=asdict(
+            JobStatusResponse(
+                id=job_id,
+                status=job.status,
+                trials=trials,
+                error=job.error,
+            )
+        ),
         message="Status retrieved",
     )
 
@@ -169,7 +172,7 @@ async def get_cluster_resources_endpoint(
         )
     return APIResponse(
         success=True,
-        data=resources.to_dict(),
+        data={**asdict(resources), "used_cpus": resources.used_cpus, "used_gpus": resources.used_gpus},
         message="Cluster resources retrieved",
     )
 

--- a/api/main.py
+++ b/api/main.py
@@ -2,7 +2,6 @@ import logging
 import secrets
 import shutil
 import uuid
-from collections import Counter
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -113,8 +112,6 @@ async def get_status(job_id: str, _: Annotated[HTTPBasicCredentials, Depends(ver
         logger.exception("Database timeout for job %s", job_id)
         raise HTTPException(status_code=503, detail="Database is busy. Please try again later.") from e
 
-    summary_counter = Counter(t.status for t in trials_dict.values())
-    summary = {status.value: summary_counter.get(status, 0) for status in JobStatus}
     trials = [
         TrialResponse(
             id=str(tid),
@@ -127,16 +124,13 @@ async def get_status(job_id: str, _: Annotated[HTTPBasicCredentials, Depends(ver
         )
         for tid, t in trials_dict.items()
     ]
-    cluster_resources = await run_in_threadpool(get_cluster_status)
 
     return APIResponse(
         success=True,
         data=JobStatusResponse(
             id=job_id,
             status=job.status,
-            summary=summary,
             trials=trials,
-            cluster_resources=cluster_resources,
             error=job.error,
         ).to_dict(),
         message="Status retrieved",
@@ -158,6 +152,25 @@ async def delete_tuner_run(job_id: str, _: Annotated[HTTPBasicCredentials, Depen
         success=True,
         data={"id": job_id, "cancelled": cancelled},
         message="Tuning job deleted",
+    )
+
+
+@app.get("/api/resources")
+async def get_cluster_resources_endpoint(
+    _: Annotated[HTTPBasicCredentials, Depends(verify_credentials)],
+) -> APIResponse:
+    """Get current Ray cluster resource utilization."""
+    resources = await run_in_threadpool(get_cluster_status)
+    if resources is None:
+        return APIResponse(
+            success=False,
+            data={},
+            message="Cluster resources unavailable - Ray may not be initialized",
+        )
+    return APIResponse(
+        success=True,
+        data=resources.to_dict(),
+        message="Cluster resources retrieved",
     )
 
 

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -40,14 +40,35 @@ class TrialResponse:
 
 
 @dataclass
+class ClusterResources:
+    """Current Ray cluster resource utilization."""
+
+    total_cpus: int
+    total_gpus: int
+    used_cpus: int
+    used_gpus: int
+    available_cpus: int
+    available_gpus: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for API response."""
+        return {
+            "total_cpus": self.total_cpus,
+            "total_gpus": self.total_gpus,
+            "used_cpus": self.used_cpus,
+            "used_gpus": self.used_gpus,
+            "available_cpus": self.available_cpus,
+            "available_gpus": self.available_gpus,
+        }
+
+
+@dataclass
 class JobStatusResponse:
     """Job status response for API."""
 
     id: str
     status: JobStatus
-    summary: dict[str, int]
     trials: list[TrialResponse]
-    cluster_resources: str
     error: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
@@ -55,9 +76,7 @@ class JobStatusResponse:
         result = {
             "id": self.id,
             "status": self.status,
-            "summary": self.summary,
             "trials": [vars(t) for t in self.trials],
-            "cluster_resources": self.cluster_resources,
         }
         if self.error:
             result["error"] = self.error

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -2,7 +2,6 @@
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
 
 from api.gromacs.config import TrialConfig
 
@@ -58,17 +57,6 @@ class ClusterResources:
         """Calculate used GPUs."""
         return self.total_gpus - self.available_gpus
 
-    def to_dict(self) -> dict[str, Any]:
-        """Convert to dictionary for API response."""
-        return {
-            "total_cpus": self.total_cpus,
-            "total_gpus": self.total_gpus,
-            "available_cpus": self.available_cpus,
-            "available_gpus": self.available_gpus,
-            "used_cpus": self.used_cpus,
-            "used_gpus": self.used_gpus,
-        }
-
 
 @dataclass
 class JobStatusResponse:
@@ -78,14 +66,3 @@ class JobStatusResponse:
     status: JobStatus
     trials: list[TrialResponse]
     error: str | None = None
-
-    def to_dict(self) -> dict[str, Any]:
-        """Convert to dictionary for API response."""
-        result = {
-            "id": self.id,
-            "status": self.status,
-            "trials": [vars(t) for t in self.trials],
-        }
-        if self.error:
-            result["error"] = self.error
-        return result

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -45,20 +45,28 @@ class ClusterResources:
 
     total_cpus: int
     total_gpus: int
-    used_cpus: int
-    used_gpus: int
     available_cpus: int
     available_gpus: int
+
+    @property
+    def used_cpus(self) -> int:
+        """Calculate used CPUs."""
+        return self.total_cpus - self.available_cpus
+
+    @property
+    def used_gpus(self) -> int:
+        """Calculate used GPUs."""
+        return self.total_gpus - self.available_gpus
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for API response."""
         return {
             "total_cpus": self.total_cpus,
             "total_gpus": self.total_gpus,
-            "used_cpus": self.used_cpus,
-            "used_gpus": self.used_gpus,
             "available_cpus": self.available_cpus,
             "available_gpus": self.available_gpus,
+            "used_cpus": self.used_cpus,
+            "used_gpus": self.used_gpus,
         }
 
 

--- a/api/utils.py
+++ b/api/utils.py
@@ -79,8 +79,8 @@ def get_cluster_status() -> ClusterResources | None:
                 available_cpus=int(avail.get("CPU", 0)),
                 available_gpus=int(avail.get("GPU", 0)),
             )
-        except Exception as e:
-            logger.exception("Error fetching cluster status: %s", e)
+        except Exception:
+            logger.exception("Error fetching cluster status.")
             return None
 
     try:

--- a/api/utils.py
+++ b/api/utils.py
@@ -73,17 +73,11 @@ def get_cluster_status() -> ClusterResources | None:
             if not ray.is_initialized():
                 return None
             total, avail = ray.cluster_resources(), ray.available_resources()
-            total_cpus = int(total.get("CPU", 0))
-            total_gpus = int(total.get("GPU", 0))
-            used_cpus = total_cpus - int(avail.get("CPU", 0))
-            used_gpus = total_gpus - int(avail.get("GPU", 0))
             return ClusterResources(
-                total_cpus=total_cpus,
-                total_gpus=total_gpus,
-                used_cpus=used_cpus,
-                used_gpus=used_gpus,
-                available_cpus=total_cpus - used_cpus,
-                available_gpus=total_gpus - used_gpus,
+                total_cpus=int(total.get("CPU", 0)),
+                total_gpus=int(total.get("GPU", 0)),
+                available_cpus=int(avail.get("CPU", 0)),
+                available_gpus=int(avail.get("GPU", 0)),
             )
         except Exception as e:
             logger.exception("Error fetching cluster status: %s", e)

--- a/api/utils.py
+++ b/api/utils.py
@@ -10,10 +10,12 @@ import time
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from pathlib import Path
+from typing import Any
 
 import ray
 
 from api.config import JOBS_DIR, TPR_DIR
+from api.schemas import ClusterResources
 
 logger = logging.getLogger(__name__)
 
@@ -54,40 +56,49 @@ def sha256_of_file(path: Path | str, chunk_size: int = 8192) -> str:
     return hasher.hexdigest()
 
 
-_cluster_status_cache = {"status": "N/A", "time": 0.0}
+_cluster_status_cache: dict[str, Any] = {"data": None, "time": 0.0}
 _cluster_status_executor = ThreadPoolExecutor(max_workers=1)
 CLUSTER_STATUS_TTL = 10.0
 RAY_FETCH_TIMEOUT = 4.0
 
 
-def get_cluster_status() -> str:
+def get_cluster_status() -> ClusterResources | None:
     """Get current Ray cluster resource usage with caching."""
     now = time.time()
     if now - _cluster_status_cache["time"] < CLUSTER_STATUS_TTL:
-        return _cluster_status_cache["status"]
+        return _cluster_status_cache["data"]
 
-    def _fetch() -> str:
+    def _fetch() -> ClusterResources | None:
         try:
             if not ray.is_initialized():
-                return _cluster_status_cache["status"]
+                return None
             total, avail = ray.cluster_resources(), ray.available_resources()
-            used_cpu = int(total.get("CPU", 0) - avail.get("CPU", 0))
-            used_gpu = int(total.get("GPU", 0) - avail.get("GPU", 0))
-            return f"{used_cpu}/{int(total.get('CPU', 0))} CPUs, {used_gpu}/{int(total.get('GPU', 0))} GPUs used"
+            total_cpus = int(total.get("CPU", 0))
+            total_gpus = int(total.get("GPU", 0))
+            used_cpus = total_cpus - int(avail.get("CPU", 0))
+            used_gpus = total_gpus - int(avail.get("GPU", 0))
+            return ClusterResources(
+                total_cpus=total_cpus,
+                total_gpus=total_gpus,
+                used_cpus=used_cpus,
+                used_gpus=used_gpus,
+                available_cpus=total_cpus - used_cpus,
+                available_gpus=total_gpus - used_gpus,
+            )
         except Exception as e:
             logger.exception("Error fetching cluster status: %s", e)
-            return _cluster_status_cache["status"]
+            return None
 
     try:
-        status = _cluster_status_executor.submit(_fetch).result(timeout=RAY_FETCH_TIMEOUT)
+        data = _cluster_status_executor.submit(_fetch).result(timeout=RAY_FETCH_TIMEOUT)
     except TimeoutError:
         logger.warning("ray.cluster_resources() timed out after %.1fs", RAY_FETCH_TIMEOUT)
         _cluster_status_cache["time"] = time.time()
-        return _cluster_status_cache["status"]
+        return _cluster_status_cache["data"]
 
-    _cluster_status_cache["status"] = status
+    _cluster_status_cache["data"] = data
     _cluster_status_cache["time"] = time.time()
-    return status
+    return data
 
 
 def tail(file: Path | str, n: int = 10) -> str:

--- a/openapi/gromacs-tuner-openapi.yaml
+++ b/openapi/gromacs-tuner-openapi.yaml
@@ -101,6 +101,20 @@ paths:
               schema:
                 $ref: "#/components/schemas/SuccessResponseWithHealth"
 
+  /resources:
+    get:
+      summary: Get cluster resources.
+      description: Get current Ray cluster resource utilization.
+      security:
+        - basicAuth: []
+      responses:
+        "200":
+          description: Cluster resources retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponseWithResources"
+
 components:
   securitySchemes:
     basicAuth:
@@ -138,10 +152,6 @@ components:
               type: string
             status:
               type: string
-            summary:
-              type: object
-              additionalProperties:
-                type: integer
             trials:
               type: array
               items:
@@ -162,8 +172,6 @@ components:
                   performance:
                     type: number
                     nullable: true
-            cluster_resources:
-              type: string
             error:
               type: string
               nullable: true
@@ -201,6 +209,40 @@ components:
               type: string
             cancelled:
               type: boolean
+        message:
+          type: string
+        error:
+          type: object
+          nullable: true
+
+    SuccessResponseWithResources:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          type: object
+          description: Cluster resources information.
+          nullable: true
+          properties:
+            total_cpus:
+              type: integer
+              description: Total CPU cores available in the Ray cluster.
+            total_gpus:
+              type: integer
+              description: Total GPUs available in the Ray cluster.
+            used_cpus:
+              type: integer
+              description: CPU cores currently in use across the cluster.
+            used_gpus:
+              type: integer
+              description: GPUs currently in use across the cluster.
+            available_cpus:
+              type: integer
+              description: CPU cores available for new tasks.
+            available_gpus:
+              type: integer
+              description: GPUs available for new tasks.
         message:
           type: string
         error:

--- a/openapi/gromacs-tuner-openapi.yaml
+++ b/openapi/gromacs-tuner-openapi.yaml
@@ -222,8 +222,7 @@ components:
           type: boolean
         data:
           type: object
-          description: Cluster resources information.
-          nullable: true
+          description: Cluster resources information. Returns empty object when unavailable.
           properties:
             total_cpus:
               type: integer


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a secured endpoint to retrieve current cluster resource utilization (total/used/available CPUs & GPUs).
* **Refactor**
  * Simplified the status endpoint by removing the trial summary and cluster resource details from its response.
* **Documentation**
  * Updated API specification to document the new resources endpoint and removed fields from the status response schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->